### PR TITLE
#22 Updated docs for building on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ This project uses protocol buffers to communicate with MediaPipe, and it is nece
     # For Desktop CPU
     make cpu
 
+    # For Mac CPU
+    make mac_cpu
+
     # For Android
     make android_arm
     ```


### PR DESCRIPTION
Quick fix for Readme. Added documentation about building MediaPipeUnityPlugin for OS X (command `make mac_cpu`)