### PR TITLE
Made it possible to run editor while on iOS/Android platform target

### DIFF
--- a/Assets/MediaPipe/SDK/Scripts/PInvoke/SafeNativeMethods.cs
+++ b/Assets/MediaPipe/SDK/Scripts/PInvoke/SafeNativeMethods.cs
@@ -5,7 +5,7 @@ namespace Mediapipe {
   internal static partial class SafeNativeMethods {
     private const string MediaPipeLibrary =
 #if UNITY_EDITOR
-        "mediapipe_c";
+      "mediapipe_c";
 #elif UNITY_IOS
       "__Internal";
 #elif UNITY_ANDROID

--- a/Assets/MediaPipe/SDK/Scripts/PInvoke/SafeNativeMethods.cs
+++ b/Assets/MediaPipe/SDK/Scripts/PInvoke/SafeNativeMethods.cs
@@ -4,7 +4,9 @@ namespace Mediapipe {
   [SuppressUnmanagedCodeSecurityAttribute]
   internal static partial class SafeNativeMethods {
     private const string MediaPipeLibrary =
-#if UNITY_IOS
+#if UNITY_EDITOR
+        "mediapipe_c";
+#elif UNITY_IOS
       "__Internal";
 #elif UNITY_ANDROID
       "mediapipe_jni";

--- a/Assets/MediaPipe/SDK/Scripts/PInvoke/UnsafeNativeMethods.cs
+++ b/Assets/MediaPipe/SDK/Scripts/PInvoke/UnsafeNativeMethods.cs
@@ -5,7 +5,7 @@ namespace Mediapipe {
   internal static partial class UnsafeNativeMethods {
     private const string MediaPipeLibrary =
 #if UNITY_EDITOR
-        "mediapipe_c";
+      "mediapipe_c";
 #elif UNITY_IOS
       "__Internal";
 #elif UNITY_ANDROID

--- a/Assets/MediaPipe/SDK/Scripts/PInvoke/UnsafeNativeMethods.cs
+++ b/Assets/MediaPipe/SDK/Scripts/PInvoke/UnsafeNativeMethods.cs
@@ -4,7 +4,9 @@ namespace Mediapipe {
   [SuppressUnmanagedCodeSecurityAttribute]
   internal static partial class UnsafeNativeMethods {
     private const string MediaPipeLibrary =
-#if UNITY_IOS
+#if UNITY_EDITOR
+        "mediapipe_c";
+#elif UNITY_IOS
       "__Internal";
 #elif UNITY_ANDROID
       "mediapipe_jni";


### PR DESCRIPTION
It wasn't possible to run editor while selected mobile platform (ex. android), due to wrong pre-processor directives in dll pickers