### PR TITLE
Copy Android build/* to host directory failed

### DIFF
--- a/build.py
+++ b/build.py
@@ -152,8 +152,15 @@ class BuildCommand(Command):
       self.console.info('Built native libraries for iOS')
 
     self.console.info('Installing...')
-    # _copytree fails on Windows, so run `cp -r` instead.
-    self._run_command(['cp', '-r', f'{_BUILD_PATH}/*', _INSTALL_PATH])
+
+    if self.android:
+      # When build Android AAR in linux-docker on windows, will copy build/* to host directory failed.
+      # The path need to one up level.
+      self._run_command(['cp', '-r', f'../{_BUILD_PATH}/*', _INSTALL_PATH])
+    else:
+      # _copytree fails on Windows, so run `cp -r` instead.
+      self._run_command(['cp', '-r', f'{_BUILD_PATH}/*', _INSTALL_PATH])
+
     self.console.info('Installed')
 
   def _is_windows(self):

--- a/docker/linux/x86_64/pacman.patch
+++ b/docker/linux/x86_64/pacman.patch
@@ -9,7 +9,7 @@ index a12f279..d3a668f 100644
 +# https://serverfault.com/questions/1052963/pacman-doesnt-work-in-docker-image
 +RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
 +    curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
-+    sbsdtar -C / -xvf "$patched_glibc"
++    bsdtar -C / -xvf "$patched_glibc"
 +
  # Create a privileged user
  RUN pacman -Syuu sudo --needed --noconfirm


### PR DESCRIPTION
When build Android AAR in linux-docker on windows, will copy build/* to host directory failed. The path need to one up level.