### PR TITLE
Updated WORKSPACE file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,8 +77,8 @@ http_archive(
 
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-master",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+    strip_prefix = "rules_cc-main",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
 )
 
 http_archive(


### PR DESCRIPTION
Changed url and prefix for c++ rules to reflect renaming of branch as seen here: https://github.com/bazelbuild/rules_cc/issues/107
fixes #210