### PR TITLE
"api_level = 21," added to WORKSPACE file in NDK configuration

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -301,7 +301,7 @@ http_archive(
 # You may run setup_android.sh to install Android SDK and NDK.
 android_ndk_repository(
     name = "androidndk",
-	api_level = 21,
+    api_level = 21,
 )
 
 android_sdk_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -301,6 +301,7 @@ http_archive(
 # You may run setup_android.sh to install Android SDK and NDK.
 android_ndk_repository(
     name = "androidndk",
+	api_level = 21,
 )
 
 android_sdk_repository(


### PR DESCRIPTION
Modified WORKSPACE file to fix issues when using android library when building with Docker.

Linked issues/comments describing in more detail:
https://github.com/google/mediapipe/issues/1224#issuecomment-745190852
https://github.com/homuler/MediaPipeUnityPlugin/issues/269