### PR TITLE
fix: synchronize the input image and the output annotation

### DIFF
--- a/Assets/Mediapipe/Samples/Common/Scripts/Solution.cs
+++ b/Assets/Mediapipe/Samples/Common/Scripts/Solution.cs
@@ -77,6 +77,8 @@ namespace Mediapipe.Unity
       {
         screen.uvRect = new UnityEngine.Rect(0, 1, 1, -1);
       }
+
+      screen.texture = imageSource.GetCurrentTexture();
     }
 
     protected static void SetupAnnotationController<T>(AnnotationController<T> annotationController, ImageSource imageSource, bool expectedToBeMirrored = false) where T : HierarchicalAnnotation
@@ -105,6 +107,15 @@ namespace Mediapipe.Unity
       {
         textureFrame.ReadTextureFromOnCPU(sourceTexture);
       }
+    }
+
+    protected static void UpdateScreenSync(RawImage screen, TextureFrame textureFrame)
+    {
+      if (!(screen.texture is Texture2D))
+      {
+        screen.texture = new Texture2D(textureFrame.width, textureFrame.height, TextureFormat.RGBA32, false);
+      }
+      textureFrame.CopyTexture(screen.texture);
     }
   }
 }

--- a/Assets/Mediapipe/Samples/Common/Scripts/Solution.cs
+++ b/Assets/Mediapipe/Samples/Common/Scripts/Solution.cs
@@ -114,6 +114,7 @@ namespace Mediapipe.Unity
       if (!(screen.texture is Texture2D))
       {
         screen.texture = new Texture2D(textureFrame.width, textureFrame.height, TextureFormat.RGBA32, false);
+        screen.uvRect = new UnityEngine.Rect(0, 0, 1, 1);
       }
       textureFrame.CopyTexture(screen.texture);
     }

--- a/Assets/Mediapipe/Samples/Scenes/Box Tracking/BoxTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Box Tracking/BoxTrackingSolution.cs
@@ -72,7 +72,6 @@ namespace Mediapipe.Unity.BoxTracking
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
 
@@ -114,6 +113,9 @@ namespace Mediapipe.Unity.BoxTracking
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var trackedDetections = _graphRunner.FetchNextValue();
           _trackedDetectionsAnnotationController.DrawNow(trackedDetections);

--- a/Assets/Mediapipe/Samples/Scenes/Face Detection/FaceDetectionSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Face Detection/FaceDetectionSolution.cs
@@ -78,7 +78,6 @@ namespace Mediapipe.Unity.FaceDetection
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Model Selection = {modelType}");
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
@@ -121,6 +120,9 @@ namespace Mediapipe.Unity.FaceDetection
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var detections = _graphRunner.FetchNextValue();
           _faceDetectionsAnnotationController.DrawNow(detections);

--- a/Assets/Mediapipe/Samples/Scenes/Face Mesh/FaceMeshSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Face Mesh/FaceMeshSolution.cs
@@ -87,7 +87,6 @@ namespace Mediapipe.Unity.FaceMesh
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Max Num Faces = {maxNumFaces}");
       Logger.LogInfo(TAG, $"Refine Landmarks = {refineLandmarks}");
@@ -138,6 +137,9 @@ namespace Mediapipe.Unity.FaceMesh
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _faceDetectionsAnnotationController.DrawNow(value.faceDetections);

--- a/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationSolution.cs
@@ -71,7 +71,6 @@ namespace Mediapipe.Unity.HairSegmentation
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
 
@@ -114,6 +113,9 @@ namespace Mediapipe.Unity.HairSegmentation
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var hairMask = _graphRunner.FetchNextValue();
           _hairMaskAnnotationController.DrawNow(hairMask);

--- a/Assets/Mediapipe/Samples/Scenes/Hand Tracking/HandTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Hand Tracking/HandTrackingSolution.cs
@@ -81,7 +81,6 @@ namespace Mediapipe.Unity.HandTracking
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Max Num Hands = {maxNumHands}");
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
@@ -132,6 +131,9 @@ namespace Mediapipe.Unity.HandTracking
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _palmDetectionsAnnotationController.DrawNow(value.palmDetections);

--- a/Assets/Mediapipe/Samples/Scenes/Holistic/HolisticTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Holistic/HolisticTrackingSolution.cs
@@ -92,7 +92,7 @@ namespace Mediapipe.Unity.Holistic
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
+
       _worldAnnotationArea.localEulerAngles = imageSource.rotation.Reverse().GetEulerAngles();
 
       Logger.LogInfo(TAG, $"Model Complexity = {modelComplexity}");
@@ -148,6 +148,9 @@ namespace Mediapipe.Unity.Holistic
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _poseDetectionAnnotationController.DrawNow(value.poseDetection);

--- a/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
@@ -91,7 +91,6 @@ namespace Mediapipe.Unity.InstantMotionTracking
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
 
@@ -136,6 +135,9 @@ namespace Mediapipe.Unity.InstantMotionTracking
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _trackedAnchorDataAnnotationController.DrawNow(value);

--- a/Assets/Mediapipe/Samples/Scenes/Iris Tracking/IrisTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Iris Tracking/IrisTrackingSolution.cs
@@ -74,7 +74,6 @@ namespace Mediapipe.Unity.IrisTracking
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
 
@@ -120,6 +119,9 @@ namespace Mediapipe.Unity.IrisTracking
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _faceDetectionsAnnotationController.DrawNow(value.faceDetections);

--- a/Assets/Mediapipe/Samples/Scenes/Object Detection/ObjectDetectionSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Object Detection/ObjectDetectionSolution.cs
@@ -72,7 +72,6 @@ namespace Mediapipe.Unity.ObjectDetection
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Running Mode = {runningMode}");
 
@@ -114,6 +113,9 @@ namespace Mediapipe.Unity.ObjectDetection
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var detections = _graphRunner.FetchNextDetections();
           _outputDetectionsAnnotationController.DrawNow(detections);

--- a/Assets/Mediapipe/Samples/Scenes/Objectron/ObjectronSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Objectron/ObjectronSolution.cs
@@ -86,7 +86,6 @@ namespace Mediapipe.Unity.Objectron
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
 
       Logger.LogInfo(TAG, $"Category = {category}");
       Logger.LogInfo(TAG, $"Max Num Objects = {maxNumObjects}");
@@ -137,6 +136,9 @@ namespace Mediapipe.Unity.Objectron
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _liftedObjectsAnnotationController.DrawNow(value.liftedObjects);

--- a/Assets/Mediapipe/Samples/Scenes/Pose Tracking/PoseTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Pose Tracking/PoseTrackingSolution.cs
@@ -87,7 +87,7 @@ namespace Mediapipe.Unity.PoseTracking
       }
       // NOTE: The _screen will be resized later, keeping the aspect ratio.
       SetupScreen(_screen, imageSource);
-      _screen.texture = imageSource.GetCurrentTexture();
+
       _worldAnnotationArea.localEulerAngles = imageSource.rotation.Reverse().GetEulerAngles();
 
       Logger.LogInfo(TAG, $"Model Complexity = {modelComplexity}");
@@ -138,6 +138,9 @@ namespace Mediapipe.Unity.PoseTracking
 
         if (runningMode == RunningMode.Sync)
         {
+          // TODO: copy texture before `textureFrame` is released
+          UpdateScreenSync(_screen, textureFrame);
+
           // When running synchronously, wait for the outputs here (blocks the main thread).
           var value = _graphRunner.FetchNextValue();
           _poseDetectionAnnotationController.DrawNow(value.poseDetection);


### PR DESCRIPTION
fix #302 

As described at https://github.com/homuler/MediaPipeUnityPlugin/issues/302#issuecomment-961018299, the camera image can advance while the main thread is being blocked in synchronous mode.

By this change, the camera image will be copied to the screen on CPU when running in synchronous mode.