### PR TITLE
Fix error "No rules_cc - master.zip file not found 404 error"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,8 +77,8 @@ http_archive(
 
 http_archive(
     name = "rules_cc",
-    strip_prefix = "rules_cc-master",
-    urls = ["https://github.com/bazelbuild/rules_cc/archive/master.zip"],
+    strip_prefix = "rules_cc-main",
+    urls = ["https://github.com/bazelbuild/rules_cc/archive/main.zip"],
 )
 
 http_archive(


### PR DESCRIPTION
Fix build error "No rules_cc - master.zip file not found 404 error" by changing "master" to "main" in WORKSPACE file, since Bazel renamed the repo branch. See also https://github.com/google/mediapipe/issues/2232#issuecomment-872112785 