### PR TITLE
build: support M1 Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,9 +419,9 @@ If you are unsure of the cause, try checking the dependent libraries using `ldd`
 
 #### 5. Dependent libraries are not loaded
 
-On Windows, when you're using local OpenCV (i.e. `--opencv=local`), `opencv_3410world.dll` must be loaded **before** `libmediapipe_c.so`.\
+On Windows, when you're using local OpenCV (i.e. `--opencv=local`), `opencv_3416world.dll` must be loaded **before** `libmediapipe_c.so`.\
 Unfortunately, currently no easy way to do this is known.\
-As a workaround, try loading both `opencv_3410world.dll` and `libmediapipe_c.dll` on startup.
+As a workaround, try loading both `opencv_3416world.dll` and `libmediapipe_c.dll` on startup.
 
 ![load-on-startup](https://user-images.githubusercontent.com/4690128/135591282-8a2011b1-9ae8-4a6a-a5fb-cc3a21f1125f.png)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -219,9 +219,9 @@ http_archive(
 http_archive(
     name = "opencv",
     build_file = "@//third_party:opencv.BUILD",
-    sha256 = "1ed6f5b02a7baf14daca04817566e7c98ec668cec381e0edf534fa49f10f58a2",
-    strip_prefix = "opencv-3.4.10",
-    urls = ["https://github.com/opencv/opencv/archive/3.4.10.tar.gz"],
+    sha256 = "5e37b791b2fe42ed39b52d9955920b951ee42d5da95f79fbc9765a08ef733399",
+    strip_prefix = "opencv-3.4.16",
+    urls = ["https://github.com/opencv/opencv/archive/3.4.16.tar.gz"],
 )
 
 new_local_repository(

--- a/third_party/mediapipe_workaround.diff
+++ b/third_party/mediapipe_workaround.diff
@@ -1,3 +1,31 @@
+diff --git a/mediapipe/BUILD b/mediapipe/BUILD
+index 1171ea6..5f1994d 100644
+--- a/mediapipe/BUILD
++++ b/mediapipe/BUILD
+@@ -74,6 +74,7 @@ alias(
+     name = "macos",
+     actual = select({
+         ":macos_i386": ":macos_i386",
++        ":macos_arm64": "macos_arm64",
+         ":macos_x86_64": ":macos_x86_64",
+         "//conditions:default": ":macos_i386",  # Arbitrarily chosen from above.
+     }),
+@@ -119,6 +120,15 @@ config_setting(
+     visibility = ["//visibility:public"],
+ )
+ 
++config_setting(
++    name = "macos_arm64",
++    values = {
++        "apple_platform_type": "macos",
++        "cpu": "darwin_arm64",
++    },
++    visibility = ["//visibility:public"],
++)
++
+ [
+     config_setting(
+         name = arch,
 diff --git a/mediapipe/calculators/tensor/BUILD b/mediapipe/calculators/tensor/BUILD
 index 72c2f51..79929e0 100644
 --- a/mediapipe/calculators/tensor/BUILD

--- a/third_party/opencv_windows.BUILD
+++ b/third_party/opencv_windows.BUILD
@@ -19,9 +19,9 @@ licenses(["notice"])  # BSD license
 
 exports_files(["LICENSE"])
 
-OPENCV_VERSION = "3410"  # 3.4.10
+OPENCV_VERSION = "3416"  # 3.4.16
 
-# The following build rule assumes that the executable "opencv-3.4.10-vc14_vc15.exe"
+# The following build rule assumes that the executable "opencv-3.4.16-vc14_vc15.exe"
 # is downloaded and the files are extracted to local.
 # If you install OpenCV separately, please modify the build rule accordingly.
 cc_library(


### PR DESCRIPTION
related to #331

### Major changes
- enable us to build native libraries on m1 mac
- upgrade OpenCV (we cannot build 3.4.10 on m1 mac)