### PR TITLE
doc: update default OpenCV version for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ If the command finishes successfully, required files will be installed to your h
 
 1. (Optional) Install Opencv
 
-   By default, it is assumed that OpenCV 3.4.10 is installed under `C:\opencv`.\
+   By default, it is assumed that OpenCV 3.4.16 is installed under `C:\opencv`.\
    If your version or path is different, please edit [third_party/opencv_windows.BUILD](https://github.com/homuler/MediaPipeUnityPlugin/blob/master/third_party/opencv_windows.BUILD) and [WORKSPACE](https://github.com/homuler/MediaPipeUnityPlugin/blob/master/WORKSPACE).
 
 1. Install NuGet, and ensure you can run them


### PR DESCRIPTION
I think the default OpenCV version for Windows is set according to opencv_windows.BUILD file https://github.com/homuler/MediaPipeUnityPlugin/blob/b3d122f65ce15e2c144ef1cacbf1e2fd62ef530e/third_party/opencv_windows.BUILD#L22

The line was changed from 3.4.10 to 3.4.16 in #366 and part of the README.md file is already updated https://github.com/homuler/MediaPipeUnityPlugin/blob/bed2f478eddf3b8be106adcc2044e576e8337e22/README.md#L422