### PR TITLE
Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,16 @@ name: Bug Report Form
 description: Report a bug/issue that you found.
 title: '[BUG] bug name here'
 body:
+  - type: markdown
+    attributes:
+      value: "## Before you continue, please search our open/closed issues to see if a similar issue has been addressed."
+
+  - type: checkboxes
+    attributes:
+      label: I have searched through the issues and didn't find my problem.
+      options:
+        - label: Confirm
+
   - type: input
     attributes:
       label: OS Platform and Distribution

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug Report
+description: Report a bug/issue that you found.
+title: '[BUG] <bug name>'
+body:
+  - type: input
+    attributes:
+      label: OS Platform and Distribution
+      description: List your OS and distribution here (e.g., Linux Ubuntu 20.04)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Target Platform and Distribution
+      description: List your target OS and distribution here. This is where your code will run in production. (e.g., Linux Ubuntu 20.04)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Mobile Device (if target is Android/iOS/other mobile OS)
+      description: List your mobile device make and model (Samsung, Apple etc);
+
+  - type: input
+    attributes:
+      label: Android NDK version (if target is Android)
+
+  - type: input
+    attributes:
+      label: XCode version (if target is iOS)
+
+  - type: input
+    attributes:
+      label: MediaPipeUnityPlugin version or commit id
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Bazel version or commit id
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: GCC/G++ version or commit id
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: Short description of the bug that you found. 
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What is your expected behaviour?
+      description: Describe what you expected to happen and list out what you were doing.
+      value: |
+        **Expectation**: ....
+
+        **Steps**:
+
+        1. 
+        2. 
+        3. 
+
+        Add more as needed
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Full Error Log
+      description: |
+        If you have a command line error, copy and paste it here.
+        If you have a log file, please attach Editor.log (if it occurs on Unity Editor) or Player.log (if it occurs at runtime).
+        See https://docs.unity3d.com/Manual/LogFiles.html
+      value: |
+        <details><summary>Error Log</summary><p>
+
+        ```
+          // put code here in between the backticks or attach log file below
+        ```
+        </p></details>
+
+        **Put images here if applicable**
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Possible fixes or solutions
+      description: List any possible fixes/suggestions that you have in mind that could solve this issue.
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this bug?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -99,5 +99,3 @@ body:
     attributes:
       label: Additional information
       description: Is there anything else we should know about this bug?
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,7 @@ body:
       label: I have searched through the issues and didn't find my problem.
       options:
         - label: Confirm
+          required: true
 
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/build-installation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-installation-issue.yml
@@ -94,5 +94,3 @@ body:
     attributes:
       label: Additional information
       description: Is there anything else we should know about this problem?
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/build-installation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-installation-issue.yml
@@ -11,6 +11,7 @@ body:
       label: I have searched through the issues and didn't find my problem.
       options:
         - label: Confirm
+          required: true
 
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/build-installation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-installation-issue.yml
@@ -1,11 +1,11 @@
-name: Bug Report Form
-description: Report a bug/issue that you found.
-title: '[BUG] bug name here'
+name: Build Installation Issue Form
+description: Report issues that you found while building/installing the project.
+title: '[BUILD ISSUE] issue name here'
 body:
   - type: input
     attributes:
       label: OS Platform and Distribution
-      description: List your OS and distribution here (e.g., Linux Ubuntu 20.04, Windows 10 etc.)
+      description: List your OS and distribution here (e.g., Linux Ubuntu 20.04, Windows 10, etc.)
     validations:
       required: true
 
@@ -49,8 +49,8 @@ body:
 
   - type: textarea
     attributes:
-      label: Bug description
-      description: Short description of the bug that you found. 
+      label: Problem description
+      description: Short description of the problem that you found. 
     validations:
       required: true
 
@@ -82,7 +82,7 @@ body:
         <details><summary>Error Log</summary><p>
 
         ```
-          // put code here in between the backticks or attach log file 
+          // put code here in between the backticks or attach a log file
         ```
         </p></details>
 
@@ -92,12 +92,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Possible fixes or solutions
-      description: List any possible fixes/suggestions that you have in mind that could solve this issue.
-
-  - type: textarea
-    attributes:
       label: Additional information
-      description: Is there anything else we should know about this bug?
+      description: Is there anything else we should know about this problem?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/build-installation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/build-installation-issue.yml
@@ -2,6 +2,16 @@ name: Build Installation Issue Form
 description: Report issues that you found while building/installing the project.
 title: '[BUILD ISSUE] issue name here'
 body:
+  - type: markdown
+    attributes:
+      value: "## Before you continue, please search our open/closed issues to see if a similar issue has been addressed."
+
+  - type: checkboxes
+    attributes:
+      label: I have searched through the issues and didn't find my problem.
+      options:
+        - label: Confirm
+
   - type: input
     attributes:
       label: OS Platform and Distribution

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,22 @@
+name: Feature Request
+description: Requesting a new feature or changes to an existing feature
+title: '[FEATURE REQUEST] feature name'
+body:
+  - type: textarea
+    attributes:
+      label: Problem
+      description: Tell us about the problem and its negative impacts.
+    validations:
+      required: true
+      
+  - type: textarea
+    attributes:
+      label: Possible Solution
+      description: If you have an idea, please tell us what might solve the above problem.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this feature request?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -11,6 +11,7 @@ body:
       label: I have searched through the issues and didn't find my problem.
       options:
         - label: Confirm
+          required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,6 +2,16 @@ name: Feature Request Form
 description: Requesting a new feature or changes to an existing feature
 title: '[FEATURE REQUEST] feature name'
 body:
+  - type: markdown
+    attributes:
+      value: "## Before you continue, please search our open/closed issues to see if a similar issue has been addressed."
+
+  - type: checkboxes
+    attributes:
+      label: I have searched through the issues and didn't find my problem.
+      options:
+        - label: Confirm
+
   - type: textarea
     attributes:
       label: Problem

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: Feature Request Form
 description: Requesting a new feature or changes to an existing feature
 title: '[FEATURE REQUEST] feature name'
 body:
@@ -8,13 +8,11 @@ body:
       description: Tell us about the problem and its negative impacts.
     validations:
       required: true
-      
+
   - type: textarea
     attributes:
       label: Possible Solution
       description: If you have an idea, please tell us what might solve the above problem.
-    validations:
-      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/other-issue.yml
+++ b/.github/ISSUE_TEMPLATE/other-issue.yml
@@ -2,10 +2,6 @@ name: Other Issue Form
 description: Use this for any other issues. Do not create blank issues
 title: "[OTHER] description"
 body:
-  - type: markdown
-    attributes:
-      value: "# Other issue"
-
   - type: textarea
     attributes:
       label: What would you like to share?
@@ -14,9 +10,6 @@ body:
       required: true
 
   - type: textarea
-    id: extrainfo
     attributes:
       label: Additional information
       description: Is there anything else we should know about this issue?
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/other-issue.yml
+++ b/.github/ISSUE_TEMPLATE/other-issue.yml
@@ -2,6 +2,16 @@ name: Other Issue Form
 description: Use this for any other issues. Do not create blank issues
 title: "[OTHER] description"
 body:
+  - type: markdown
+    attributes:
+      value: "## Before you continue, please search our open/closed issues to see if a similar issue has been addressed."
+
+  - type: checkboxes
+    attributes:
+      label: I have searched through the issues and didn't find my problem.
+      options:
+        - label: Confirm
+
   - type: textarea
     attributes:
       label: What would you like to share?

--- a/.github/ISSUE_TEMPLATE/other-issue.yml
+++ b/.github/ISSUE_TEMPLATE/other-issue.yml
@@ -11,6 +11,7 @@ body:
       label: I have searched through the issues and didn't find my problem.
       options:
         - label: Confirm
+          required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/other-issue.yml
+++ b/.github/ISSUE_TEMPLATE/other-issue.yml
@@ -1,0 +1,22 @@
+name: Other Issue Form
+description: Use this for any other issues. Do not create blank issues
+title: "[OTHER] description"
+body:
+  - type: markdown
+    attributes:
+      value: "# Other issue"
+
+  - type: textarea
+    attributes:
+      label: What would you like to share?
+      description: Provide a clear and concise explanation of your issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false


### PR DESCRIPTION
This PR upgrades the current issue templates to issue forms. All the current templates now have a corresponding form. This was created as suggested in #405.

You can check out the forms [here](https://github.com/Thomas-Boi/MediaPipeUnityPlugin/issues/new/choose). Choose the options that ends with `Form` to see the forms. 

Any changes/suggestions/questions are welcomed. Before merging, let me know and I can delete the old template files as well.