### PR TITLE
Fix minor mishaps

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GlTextureBuffer.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GlTextureBuffer.cs
@@ -73,7 +73,7 @@ namespace Mediapipe
 
     public int Width()
     {
-      return SafeNativeMethods.mp_GlTexture__width(mpPtr);
+      return SafeNativeMethods.mp_GlTextureBuffer__width(mpPtr);
     }
 
     public int Height()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
@@ -101,6 +101,7 @@ namespace Tests
       }
     }
 
+    [Test]
     public void AssertOk_ShouldThrow_When_StatusIsNotOk()
     {
       using (var status = Status.FailedPrecondition())


### PR DESCRIPTION
Closes #415.

- [x] Fix `mp_GlTextureBuffer__width` typo
- [x] Add a missing `[Test]` attribute

I'm unsure about that last check though. Was that intentional or genuine miss?