### PR TITLE
build: remove android sdk/ndk repositories from WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -323,19 +323,6 @@ http_archive(
     urls = ["https://github.com/nothings/stb/archive/b42009b3b9d4ca35bc703f5310eedc74f584be58.tar.gz"],
 )
 
-# You may run setup_android.sh to install Android SDK and NDK.
-android_ndk_repository(
-    name = "androidndk",
-    # If you need to support older versions of Android, please specify the API Level.
-    # Otherwise, some symbols in libmediapipe_jni.so cannot be resolved and `DllNotFoundException` will be thrown.
-
-    # api_level = 21,
-)
-
-android_sdk_repository(
-    name = "androidsdk",
-)
-
 # iOS basic build deps.
 
 http_archive(
@@ -510,3 +497,17 @@ libedgetpu_dependencies()
 load("@coral_crosstool//:configure.bzl", "cc_crosstool")
 
 cc_crosstool(name = "crosstool")
+
+# To build the Android library, Uncomment the following lines.
+
+# android_ndk_repository(
+#     name = "androidndk",
+#     # If you need to support older versions of Android, please specify the API Level.
+#     # Otherwise, some symbols in libmediapipe_jni.so cannot be resolved and `DllNotFoundException` will be thrown.
+#
+#     # api_level = 21,
+# )
+
+# android_sdk_repository(
+#     name = "androidsdk",
+# )

--- a/build.py
+++ b/build.py
@@ -157,6 +157,9 @@ class BuildCommand(Command):
       self.console.info('Built native libraries for Desktop')
 
     if self.android:
+      self.console.v('Checking if androidsdk and androidndk repositories are configured...')
+      self._test_android_repositories()
+
       self.console.info('Building native libraries for Android...')
       self._run_command(self._build_android_commands())
       self._copy(
@@ -309,6 +312,19 @@ class BuildCommand(Command):
 
   def _build_proto_dlls_commands(self):
     return ['nuget', 'install', '-o', _NUGET_PATH, '-Source', 'https://api.nuget.org/v3/index.json']
+
+  def _test_android_repositories(self):
+    try:
+      self._run_command(['bazel', 'query', '@androidsdk//...'])
+    except:
+      self.console.error(f'"androidsdk" repository is not configured yet. You may have forgetten to edit the WORKSPACE file or set ANDROID_HOME.')
+      raise
+
+    try:
+      self._run_command(['bazel', 'query', '@androidndk//...'])
+    except:
+      self.console.error(f'"androidndk" repository is not configured yet. You may have forgetten to edit the WORKSPACE file or set ANDROID_NDK_HOME.')
+      raise
 
   def _find_latest_built_framework(self):
     zip_files = glob.glob(os.path.join(_BAZEL_OUT_PATH, '*', 'bin', 'mediapipe_api', 'objc', 'MediaPipeUnity.zip'))

--- a/docker/linux/x86_64/Dockerfile
+++ b/docker/linux/x86_64/Dockerfile
@@ -75,8 +75,8 @@ RUN yay -Sy npm --needed --noconfirm && \
     echo -e "prefix = ${NPM_PREFIX}\n" > /home/mediapipe/.npmrc && \
     npm install -g @bazel/bazelisk
 
-# install other dependencies
-RUN yay -Sy mesa nuget python-pip --needed --noconfirm && \
+# install other dependencies and tools
+RUN yay -Sy mesa nuget python-pip vim --needed --noconfirm && \
     pip install --user numpy
 
 FROM builder

--- a/docker/windows/x86_64/Dockerfile
+++ b/docker/windows/x86_64/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -L http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20210604.sfx.
 RUN bash.exe -l -c "pacman -Syuu --needed --noconfirm --noprogressbar" && `
     bash.exe -l -c "pacman -Syu --needed --noconfirm --noprogressbar" && `
     bash.exe -l -c "pacman -Sy --needed --noconfirm --noprogressbar" && `
-    bash.exe -l -c "pacman -S --needed --noconfirm git patch unzip zip p7zip" && `
+    bash.exe -l -c "pacman -S --needed --noconfirm git patch unzip vim zip p7zip" && `
     bash.exe -l -c "rm -r /var/cache/pacman/pkg/*"
 
 # Install Visual C++ Build Tools 2019 and WinSDK


### PR DESCRIPTION
Depending on the bazel version and build environment, android related errors (e.g. `ANDROID_HOME` or `ANDROID_NDK_HOME` are not set) may occur even when not building Android libraries (cf. #464 ).

This PR removes Android SDK/NDK repositories from the WORKSPACE file, though it's inconvenient when building Android libraries.