### PR TITLE
perf(sample): make sample scenes run faster in sync mode

### DIFF
--- a/Assets/Mediapipe/Samples/Common/Scripts/ImageSourceSolution.cs
+++ b/Assets/Mediapipe/Samples/Common/Scripts/ImageSourceSolution.cs
@@ -101,15 +101,12 @@ namespace Mediapipe.Unity
         // Copy current image to TextureFrame
         ReadFromImageSource(imageSource, textureFrame);
         AddTextureFrameToInputStream(textureFrame);
+        yield return new WaitForEndOfFrame();
 
         if (runningMode.IsSynchronous())
         {
           RenderCurrentFrame(textureFrame);
           yield return WaitForNextValue();
-        }
-        else
-        {
-          yield return new WaitForEndOfFrame();
         }
       }
     }

--- a/Assets/Mediapipe/Samples/Scenes/Box Tracking/BoxTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Box Tracking/BoxTrackingSolution.cs
@@ -29,7 +29,6 @@ namespace Mediapipe.Unity.BoxTracking
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Face Detection/FaceDetectionSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Face Detection/FaceDetectionSolution.cs
@@ -35,7 +35,6 @@ namespace Mediapipe.Unity.FaceDetection
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Face Mesh/FaceMeshSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Face Mesh/FaceMeshSolution.cs
@@ -52,7 +52,6 @@ namespace Mediapipe.Unity.FaceMesh
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationSolution.cs
@@ -30,7 +30,6 @@ namespace Mediapipe.Unity.HairSegmentation
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Hand Tracking/HandTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Hand Tracking/HandTrackingSolution.cs
@@ -54,7 +54,6 @@ namespace Mediapipe.Unity.HandTracking
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Holistic/HolisticTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Holistic/HolisticTrackingSolution.cs
@@ -68,7 +68,6 @@ namespace Mediapipe.Unity.Holistic
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, out var _, out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
@@ -51,7 +51,6 @@ namespace Mediapipe.Unity.InstantMotionTracking
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Iris Tracking/IrisTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Iris Tracking/IrisTrackingSolution.cs
@@ -37,7 +37,6 @@ namespace Mediapipe.Unity.IrisTracking
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/MediaPipe Video/MediaPipeVideoSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/MediaPipe Video/MediaPipeVideoSolution.cs
@@ -60,12 +60,11 @@ namespace Mediapipe.Unity.MediaPipeVideo
     {
       if (graphRunner.configType == GraphRunner.ConfigType.OpenGLES)
       {
-        yield return new WaitForEndOfFrame();
+        yield break;
       }
-      else if (runningMode == RunningMode.Sync)
+      if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Object Detection/ObjectDetectionSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Object Detection/ObjectDetectionSolution.cs
@@ -29,7 +29,6 @@ namespace Mediapipe.Unity.ObjectDetection
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Objectron/ObjectronSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Objectron/ObjectronSolution.cs
@@ -52,7 +52,6 @@ namespace Mediapipe.Unity.Objectron
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {

--- a/Assets/Mediapipe/Samples/Scenes/Pose Tracking/PoseTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Pose Tracking/PoseTrackingSolution.cs
@@ -60,7 +60,6 @@ namespace Mediapipe.Unity.PoseTracking
       if (runningMode == RunningMode.Sync)
       {
         var _ = graphRunner.TryGetNext(out var _, out var _, out var _, out var _, true);
-        yield return new WaitForEndOfFrame();
       }
       else if (runningMode == RunningMode.NonBlockingSync)
       {


### PR DESCRIPTION
related to #428, #471 

This PR makes sample scenes run faster in synchronous mode.
With this change, one frame will be consumed to run the `CalculatorGraph`, which means that if the sample app runs at 60FPS and the `CalculatorGraph` runs faster than 60FPS, the main thread won't be blocked even in sync mode.

The downside is that the performance of the Non-Blocking sync mode, which should allow the sample app to run faster in theory,  will be degraded in some cases.
However, in environments where the sample app runs faster than 60FPS, this mode will still be superior.