### PR TITLE
build: keep the directory structure of protobuf source files

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00f445ea02a2765e8bf57d5341a150f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Calculator.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Calculator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 13ae74449b9e7b5f5ac397e202a3e577
+guid: bb6752375d46fcfab80ce60282bace77
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/CalculatorOptions.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/CalculatorOptions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7505da3ce11608a6093315b4b9cb58fb
+guid: 0cb942f2d3bb91bfd86552daa2d128fb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18b6374b16ee582828755950791715aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Classification.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Classification.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 783e5d59c9902c475866fa9f8e9e5bc9
+guid: f38215582182a0826954a8789b14676a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Detection.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Detection.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 19c7d9284be6c565dbb88e58e931833f
+guid: 8959a6aaf727953d7bf3e26020dc1421
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Landmark.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Landmark.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c39644006f7358a459ade6e7a45161b7
+guid: 78c597cedf10ba4f8994d0386ada83f9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/LocationData.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/LocationData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 337271b467f7a3f7c83e86296b50d26c
+guid: 2a74389b68d1b8516a3d72cf9140826a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/MatrixData.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/MatrixData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c49ec041502b5f594bc1ff898dbe6874
+guid: 929f5350423bf1842a3e76a8bf6398c6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Rasterization.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Rasterization.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 45a80c4244106da5cbb2a5158bf0d955
+guid: 2f67fd6ce9b7ce372baf526c3a23e33e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Rect.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/Formats/Rect.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 241902159e9673a34bb1eddf1bac3f14
+guid: 0d0ab6ed8000b4ec99584572ab00de53
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/MediapipeOptions.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/MediapipeOptions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cd1234b5f11206ad7b425fce6ad1643c
+guid: 7fb4306bf765ed020b56723aef9429ef
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/PacketFactory.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/PacketFactory.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b701337cf6f9392e48685b7a28dff2b7
+guid: 829f26255b03dd08bbdcd4815faacf47
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/PacketGenerator.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/PacketGenerator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 860976e699347f1c68f57920ba901ab7
+guid: bf6b21134f073285e9e457e2762ef4fb
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/StatusHandler.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/StatusHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cc0c19d0a4a139924be72e8c7b5c357c
+guid: b1e3e4b165949a853abfa2cdb9666bc1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/StreamHandler.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Framework/StreamHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 89b1a575de2ead240bb98c6be6a01d99
+guid: 0fd32667399239461813fefe99012c04
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cc828272b024a0ad2b509fc4ce29fec1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f7b7ea78b8b572f193e1267b8769361
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking/Calculators.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking/Calculators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a226215240e9ce01a1bb8774e5835aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking/Calculators/StickerBuffer.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/InstantMotionTracking/Calculators/StickerBuffer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c54412ad8843ede5daed7f94d259d05b
+guid: a11b00ac8e39a8b818d36a1a4f0fce79
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27b0ba85c56c1678489abb717509027e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d/Calculators.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d/Calculators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a57e0d7eade8a0e6699f334af6762774
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d/Calculators/ModelMatrix.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Graphs/ObjectDetection3d/Calculators/ModelMatrix.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: edc92de05b2aeaa7fb02a1f48950921b
+guid: ce2b8f727949ebd1fb12a76204377e2f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 220da601494e999f1875b1e01785fa7c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66b620186928987b9bc6af3676cdb2ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry/FaceGeometry.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry/FaceGeometry.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cd9413d09e334c1fa86e61fb4c7e2407
+guid: f95c0ec47a36687ba8e49a70c3261e78
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry/Mesh3D.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/FaceGeometry/Mesh3D.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 228e646af9b9ca2c18457b0461f0e737
+guid: 263876dc23a587949869ee40a64e2988
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98a1f1972567d32f28ae1128e1fffbd9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27575fc185f13650c80ab280899ee0a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/ARCaptureMetadata.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/ARCaptureMetadata.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c1d7299f7a8b7e665abdb34c4efe71dc
+guid: e4facbf66687417bca38efde0cd05615
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/AnnotationData.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/AnnotationData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7d7e9dd3fa6734af0818ae9d7f750c76
+guid: e4f57edd5720360c5b5f915972c86488
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/Object.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Modules/Objectron/Calculators/Object.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 622b8e076b83143e6b05d2a32db8cf0d
+guid: d7e192bd63a9aefc4818216dbcd906fa
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,8 +22,8 @@ versions.check(minimum_bazel_version = "3.7.2")
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+    sha256 = "62eeb544ff1ef41d786e329e1536c1d541bb9bcad27ae984d57f18f314018e66",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/build.py
+++ b/build.py
@@ -381,9 +381,8 @@ class UninstallCommand(Command):
       for f in glob.glob(os.path.join(_INSTALL_PATH, 'Plugins', 'Protobuf', '*.dll'), recursive=True):
         self._remove(f)
 
-      for f in glob.glob(os.path.join(_INSTALL_PATH, 'Scripts', 'Protobuf', '*'), recursive=True):
-        if not f.endswith('.meta'):
-          self._remove(f)
+      for f in glob.glob(os.path.join(_INSTALL_PATH, 'Scripts', 'Protobuf', '*.cs'), recursive=True):
+        self._remove(f)
 
     if self.analyzers:
       self.console.info('Uninstalling analyzers...')

--- a/mediapipe_api/BUILD
+++ b/mediapipe_api/BUILD
@@ -194,29 +194,13 @@ pkg_asset(
 pkg_zip(
     name = "mediapipe_proto_srcs",
     srcs = [
-        "//mediapipe_api/framework:calculator_cs",
-        "//mediapipe_api/framework:calculator_options_cs",
-        "//mediapipe_api/framework:mediapipe_options_cs",
-        "//mediapipe_api/framework:packet_factory_cs",
-        "//mediapipe_api/framework:packet_generator_cs",
-        "//mediapipe_api/framework:status_handler_cs",
-        "//mediapipe_api/framework:stream_handler_cs",
-        "//mediapipe_api/framework/formats:classification_cs",
-        "//mediapipe_api/framework/formats:detection_cs",
-        "//mediapipe_api/framework/formats:landmark_cs",
-        "//mediapipe_api/framework/formats:location_data_cs",
-        "//mediapipe_api/framework/formats:matrix_data_cs",
-        "//mediapipe_api/framework/formats:rasterization_cs",
-        "//mediapipe_api/framework/formats:rect_cs",
-        "//mediapipe_api/graphs/instant_motion_tracking/calculators:sticker_buffer_cs",
-        "//mediapipe_api/graphs/object_detection_3d/calculators:model_matrix_cs",
-        "//mediapipe_api/modules/face_geometry/protos:face_geometry_cs",
-        "//mediapipe_api/modules/face_geometry/protos:mesh_3d_cs",
-        "//mediapipe_api/modules/objectron/calculators:a_r_capture_metadata_cs",
-        "//mediapipe_api/modules/objectron/calculators:annotation_data_cs",
-        "//mediapipe_api/modules/objectron/calculators:object_cs",
+        "//mediapipe_api/framework:proto_srcs",
+        "//mediapipe_api/framework/formats:proto_srcs",
+        "//mediapipe_api/graphs/instant_motion_tracking/calculators:proto_srcs",
+        "//mediapipe_api/graphs/object_detection_3d/calculators:proto_srcs",
+        "//mediapipe_api/modules/face_geometry/protos:proto_srcs",
+        "//mediapipe_api/modules/objectron/calculators:proto_srcs",
     ],
-    # TODO: keep directory structure
 )
 
 pkg_zip(

--- a/mediapipe_api/framework/BUILD
+++ b/mediapipe_api/framework/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(
@@ -87,6 +88,20 @@ cc_library(
         "@com_google_mediapipe//mediapipe/framework:validated_graph_config",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":calculator_cs",
+        ":calculator_options_cs",
+        "mediapipe_options_cs",
+        "packet_factory_cs",
+        "packet_generator_cs",
+        "status_handler_cs",
+        "stream_handler_cs",
+    ],
+    prefix = "Framework",
 )
 
 csharp_proto_src(

--- a/mediapipe_api/framework/formats/BUILD
+++ b/mediapipe_api/framework/formats/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(
@@ -74,6 +75,20 @@ cc_library(
         "@com_google_mediapipe//mediapipe/framework/formats:rect_cc_proto",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":classification_cs",
+        ":detection_cs",
+        ":landmark_cs",
+        ":location_data_cs",
+        ":matrix_data_cs",
+        ":rect_cs",
+        ":rasterization_cs",
+    ],
+    prefix = "Framework/Formats",
 )
 
 csharp_proto_src(

--- a/mediapipe_api/graphs/instant_motion_tracking/calculators/BUILD
+++ b/mediapipe_api/graphs/instant_motion_tracking/calculators/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(
@@ -21,6 +22,14 @@ cc_library(
         "@com_google_mediapipe//mediapipe/graphs/instant_motion_tracking/calculators:tracked_anchor_manager_calculator",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":sticker_buffer_cs",
+    ],
+    prefix = "Graphs/InstantMotionTracking/Calculators",
 )
 
 csharp_proto_src(

--- a/mediapipe_api/graphs/object_detection_3d/calculators/BUILD
+++ b/mediapipe_api/graphs/object_detection_3d/calculators/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(
@@ -21,6 +22,14 @@ cc_library(
         "@com_google_mediapipe//mediapipe/graphs/object_detection_3d/calculators:model_matrix_cc_proto",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":model_matrix_cs",
+    ],
+    prefix = "Graphs/ObjectDetection3d/Calculators",
 )
 
 csharp_proto_src(

--- a/mediapipe_api/modules/face_geometry/protos/BUILD
+++ b/mediapipe_api/modules/face_geometry/protos/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(default_visibility = ["//visibility:public"])
@@ -19,6 +20,15 @@ cc_library(
         "@com_google_mediapipe//mediapipe/modules/face_geometry/protos:face_geometry_cc_proto",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":face_geometry_cs",
+        ":mesh_3d_cs",
+    ],
+    prefix = "Modules/FaceGeometry",
 )
 
 csharp_proto_src(

--- a/mediapipe_api/modules/objectron/calculators/BUILD
+++ b/mediapipe_api/modules/objectron/calculators/BUILD
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
 
 package(default_visibility = ["//visibility:public"])
@@ -19,6 +20,16 @@ cc_library(
         "@com_google_mediapipe//mediapipe/modules/objectron/calculators:annotation_cc_proto",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":annotation_data_cs",
+        ":object_cs",
+        ":a_r_capture_metadata_cs",
+    ],
+    prefix = "Modules/Objectron/Calculators",
 )
 
 csharp_proto_src(


### PR DESCRIPTION
This PR keeps the original directory structure under `Scripts/Protobuf` to avoid the risk of file name conflicts.