### PR TITLE
feat(sample): implement MIN_(DETECTION|TRACKING)_CONFIDENCE

### DIFF
--- a/Assets/Mediapipe/Samples/Common/Scripts/ImageSource/TextureFrame.cs
+++ b/Assets/Mediapipe/Samples/Common/Scripts/ImageSource/TextureFrame.cs
@@ -14,6 +14,10 @@ using UnityEngine.Experimental.Rendering;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class TextureFrame
   {
     public class ReleaseEvent : UnityEvent<TextureFrame> { }

--- a/Assets/Mediapipe/Samples/UI/Scripts/LogLine.cs
+++ b/Assets/Mediapipe/Samples/UI/Scripts/LogLine.cs
@@ -10,6 +10,10 @@ using UnityEngine.UI;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class LogLine : MonoBehaviour
   {
     [SerializeField] private Text _utcTimeArea;

--- a/Assets/Mediapipe/Samples/UI/Scripts/SolutionMenu.cs
+++ b/Assets/Mediapipe/Samples/UI/Scripts/SolutionMenu.cs
@@ -12,6 +12,10 @@ using UnityEngine.SceneManagement;
 
 namespace Mediapipe.Unity.UI
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class SolutionMenu : ModalContents
   {
     [SerializeField] private GameObject _solutionRowPrefab;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/ValidatedGraphConfig.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/ValidatedGraphConfig.cs
@@ -135,12 +135,13 @@ namespace Mediapipe
       return new Status(statusPtr);
     }
 
-    public CalculatorGraphConfig Config()
+    public CalculatorGraphConfig Config(ExtensionRegistry extensionRegistry = null)
     {
       UnsafeNativeMethods.mp_ValidatedGraphConfig__Config(mpPtr, out var serializedProto).Assert();
       GC.KeepAlive(this);
 
-      var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
+      var parser = extensionRegistry == null ? CalculatorGraphConfig.Parser : CalculatorGraphConfig.Parser.WithExtensionRegistry(extensionRegistry);
+      var config = serializedProto.Deserialize(parser);
       serializedProto.Dispose();
 
       return config;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eaf1a96d5b34138ccace8daecccd0520
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensor.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa3bc66960753a948bf57e2986ff316a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensor/TensorsToDetectionsCalculator.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensor/TensorsToDetectionsCalculator.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 70d76fe65decabc7c9c82d0dd487ef37
+guid: 9b0f773471b719b5f803cac686ec7653
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Util.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d691b2ca837664112adbffece01bb6f7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Util/ThresholdingCalculator.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Util/ThresholdingCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81f3d9cc258eeb1d1b47c50df48d5cf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/TensorsToDetectionsCalculator.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/TensorsToDetectionsCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70d76fe65decabc7c9c82d0dd487ef37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca02a698e823ece56862f80d08c631ba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/Color.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/Color.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12843ade4075fb5949f3170be8f1601f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/RenderData.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/RenderData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6475269ad8c98711994a2d30d2e61e4b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/Arrow.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/Arrow.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class Arrow : MonoBehaviour
   {
     [SerializeField] private Color _color = Color.white;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CircleAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CircleAnnotation.cs
@@ -8,6 +8,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class CircleAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private LineRenderer _lineRenderer;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/ConnectionListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/ConnectionListAnnotation.cs
@@ -10,6 +10,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class ConnectionListAnnotation : ListAnnotation<ConnectionAnnotation>
   {
     [SerializeField] private Color _color = Color.red;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CuboidAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CuboidAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class CuboidAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private PointListAnnotation _pointListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CuboidListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/CuboidListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class CuboidListAnnotation : ListAnnotation<CuboidAnnotation>
   {
     [SerializeField] private Color _pointColor = Color.green;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class DetectionAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private RectangleAnnotation _locationDataAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class DetectionListAnnotation : ListAnnotation<DetectionAnnotation>
   {
     [SerializeField, Range(0, 1)] private float _lineWidth = 1.0f;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/FaceLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/FaceLandmarkListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class FaceLandmarkListAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private PointListAnnotation _landmarkListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/FaceLandmarkListWithIrisAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/FaceLandmarkListWithIrisAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class FaceLandmarkListWithIrisAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private FaceLandmarkListAnnotation _faceLandmarkListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HandLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HandLandmarkListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class HandLandmarkListAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private PointListAnnotation _landmarkListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/IrisLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/IrisLandmarkListAnnotation.cs
@@ -10,6 +10,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class IrisLandmarkListAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private PointListAnnotation _landmarkListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/LabelAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/LabelAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine.UI;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class LabelAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private Text _labelText;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/LineAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/LineAnnotation.cs
@@ -8,6 +8,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class LineAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private LineRenderer _lineRenderer;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MaskAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MaskAnnotation.cs
@@ -11,6 +11,10 @@ using UnityEngine.UI;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class MaskAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private RawImage _screen;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MultiFaceLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MultiFaceLandmarkListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class MultiFaceLandmarkListAnnotation : ListAnnotation<FaceLandmarkListWithIrisAnnotation>
   {
     [SerializeField] private Color _faceLandmarkColor = Color.green;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MultiHandLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/MultiHandLandmarkListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class MultiHandLandmarkListAnnotation : ListAnnotation<HandLandmarkListAnnotation>
   {
     [SerializeField] private Color _leftLandmarkColor = Color.green;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
@@ -11,6 +11,10 @@ using mplt = Mediapipe.LocationData.Types;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class PointAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private Color _color = Color.green;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointListAnnotation.cs
@@ -11,6 +11,10 @@ using mplt = Mediapipe.LocationData.Types;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class PointListAnnotation : ListAnnotation<PointAnnotation>
   {
     [SerializeField] private Color _color = Color.green;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PoseLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PoseLandmarkListAnnotation.cs
@@ -10,6 +10,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public sealed class PoseLandmarkListAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private PointListAnnotation _landmarkListAnnotation;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleAnnotation.cs
@@ -11,6 +11,10 @@ using mplt = Mediapipe.LocationData.Types;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class RectangleAnnotation : HierarchicalAnnotation
   {
     [SerializeField] private LineRenderer _lineRenderer;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleListAnnotation.cs
@@ -9,6 +9,10 @@ using UnityEngine;
 
 namespace Mediapipe.Unity
 {
+#pragma warning disable IDE0065
+  using Color = UnityEngine.Color;
+#pragma warning restore IDE0065
+
   public class RectangleListAnnotation : ListAnnotation<RectangleAnnotation>
   {
     [SerializeField] private Color _color = Color.red;

--- a/build.py
+++ b/build.py
@@ -381,7 +381,7 @@ class UninstallCommand(Command):
       for f in glob.glob(os.path.join(_INSTALL_PATH, 'Plugins', 'Protobuf', '*.dll'), recursive=True):
         self._remove(f)
 
-      for f in glob.glob(os.path.join(_INSTALL_PATH, 'Scripts', 'Protobuf', '*.cs'), recursive=True):
+      for f in glob.glob(os.path.join(_INSTALL_PATH, 'Scripts', 'Protobuf', '**', '*.cs'), recursive=True):
         self._remove(f)
 
     if self.analyzers:

--- a/mediapipe_api/BUILD
+++ b/mediapipe_api/BUILD
@@ -194,6 +194,7 @@ pkg_asset(
 pkg_zip(
     name = "mediapipe_proto_srcs",
     srcs = [
+        "//mediapipe_api/calculators/tensor:proto_srcs",
         "//mediapipe_api/framework:proto_srcs",
         "//mediapipe_api/framework/formats:proto_srcs",
         "//mediapipe_api/graphs/instant_motion_tracking/calculators:proto_srcs",

--- a/mediapipe_api/BUILD
+++ b/mediapipe_api/BUILD
@@ -195,12 +195,14 @@ pkg_zip(
     name = "mediapipe_proto_srcs",
     srcs = [
         "//mediapipe_api/calculators/tensor:proto_srcs",
+        "//mediapipe_api/calculators/util:proto_srcs",
         "//mediapipe_api/framework:proto_srcs",
         "//mediapipe_api/framework/formats:proto_srcs",
         "//mediapipe_api/graphs/instant_motion_tracking/calculators:proto_srcs",
         "//mediapipe_api/graphs/object_detection_3d/calculators:proto_srcs",
         "//mediapipe_api/modules/face_geometry/protos:proto_srcs",
         "//mediapipe_api/modules/objectron/calculators:proto_srcs",
+        "//mediapipe_api/util:proto_srcs",
     ],
 )
 

--- a/mediapipe_api/calculators/tensor/BUILD
+++ b/mediapipe_api/calculators/tensor/BUILD
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 homuler
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "proto_srcs",
+    srcs = [
+        ":tensors_to_detections_calculator_cs",
+    ],
+)
+
+csharp_proto_src(
+    name = "tensors_to_detections_calculator_cs",
+    proto_src = "mediapipe/calculators/tensor/tensors_to_detections_calculator.proto",
+    deps = [
+        "@com_google_mediapipe//mediapipe/calculators/tensor:protos_src",
+        "@com_google_mediapipe//mediapipe/framework:protos_src",
+    ],
+)

--- a/mediapipe_api/calculators/util/BUILD
+++ b/mediapipe_api/calculators/util/BUILD
@@ -14,16 +14,17 @@ package(
 pkg_files(
     name = "proto_srcs",
     srcs = [
-        ":tensors_to_detections_calculator_cs",
+        ":thresholding_calculator_cs",
     ],
-    prefix = "Calculators/Tensor",
+    prefix = "Calculators/Util",
 )
 
 csharp_proto_src(
-    name = "tensors_to_detections_calculator_cs",
-    proto_src = "mediapipe/calculators/tensor/tensors_to_detections_calculator.proto",
+    name = "thresholding_calculator_cs",
+    proto_src = "mediapipe/calculators/util/thresholding_calculator.proto",
     deps = [
-        "@com_google_mediapipe//mediapipe/calculators/tensor:protos_src",
+        "@com_google_mediapipe//mediapipe/calculators/util:protos_src",
         "@com_google_mediapipe//mediapipe/framework:protos_src",
+        "@com_google_mediapipe//mediapipe/util:protos_src",
     ],
 )

--- a/mediapipe_api/csharp_proto_src.bzl
+++ b/mediapipe_api/csharp_proto_src.bzl
@@ -9,23 +9,18 @@
 Macro for generating C# source files corresponding to .proto files
 """
 
-def csharp_proto_src(name, proto_src, deps, import_prefix = ""):
+def csharp_proto_src(name, proto_src, deps):
     """Generate C# source code for *.proto
 
     Args:
       name: target name
       deps: label list of dependent targets
-      import_prefix: Directory where the generated source code is placed
       proto_src: target .proto file path
     """
 
-    # e.g.
-    #  If import_prefix is "Annotation" and proto_src is "mediapipe/framework/formats/annotation/rasterization", then
-    #    csharp_out -> Rasterization.cs
-    #    outdir -> $GENDIR/Annotation
     base_name = proto_src.split("/")[-1]
     csharp_out = _camelize(base_name.split(".")[0]) + ".cs"
-    outdir = "$(GENDIR)" if len(import_prefix) == 0 else "$(GENDIR)/" + import_prefix
+    outdir = "$(GENDIR)"
 
     native.genrule(
         name = name,

--- a/mediapipe_api/framework/BUILD
+++ b/mediapipe_api/framework/BUILD
@@ -95,11 +95,11 @@ pkg_files(
     srcs = [
         ":calculator_cs",
         ":calculator_options_cs",
-        "mediapipe_options_cs",
-        "packet_factory_cs",
-        "packet_generator_cs",
-        "status_handler_cs",
-        "stream_handler_cs",
+        ":mediapipe_options_cs",
+        ":packet_factory_cs",
+        ":packet_generator_cs",
+        ":status_handler_cs",
+        ":stream_handler_cs",
     ],
     prefix = "Framework",
 )

--- a/mediapipe_api/framework/formats/BUILD
+++ b/mediapipe_api/framework/formats/BUILD
@@ -143,7 +143,6 @@ csharp_proto_src(
 
 csharp_proto_src(
     name = "rasterization_cs",
-    import_prefix = "Annotation",
     proto_src = "mediapipe/framework/formats/annotation/rasterization.proto",
     deps = [
         "@com_google_mediapipe//mediapipe/framework/formats/annotation:protos_src",

--- a/mediapipe_api/graphs/instant_motion_tracking/calculators/BUILD
+++ b/mediapipe_api/graphs/instant_motion_tracking/calculators/BUILD
@@ -34,7 +34,6 @@ pkg_files(
 
 csharp_proto_src(
     name = "sticker_buffer_cs",
-    import_prefix = "Graphs/InstantMotionTracking",
     proto_src = "mediapipe/graphs/instant_motion_tracking/calculators/sticker_buffer.proto",
     deps = [
         "@com_google_mediapipe//mediapipe/graphs/instant_motion_tracking/calculators:protos_src",

--- a/mediapipe_api/graphs/object_detection_3d/calculators/BUILD
+++ b/mediapipe_api/graphs/object_detection_3d/calculators/BUILD
@@ -34,7 +34,6 @@ pkg_files(
 
 csharp_proto_src(
     name = "model_matrix_cs",
-    import_prefix = "Graphs/ObjectDetection3d",
     proto_src = "mediapipe/graphs/object_detection_3d/calculators/model_matrix.proto",
     deps = [
         "@com_google_mediapipe//mediapipe/graphs/object_detection_3d/calculators:protos_src",

--- a/mediapipe_api/util/BUILD
+++ b/mediapipe_api/util/BUILD
@@ -4,11 +4,17 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//mediapipe_api:csharp_proto_src.bzl", "csharp_proto_src")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "resource_util",
     srcs = ["resource_util_custom.cc"],
     hdrs = ["resource_util_custom.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//mediapipe_api:common",
         "@com_google_absl//absl/strings",
@@ -17,4 +23,29 @@ cc_library(
         "@com_google_mediapipe//mediapipe/util:resource_util",
     ],
     alwayslink = True,
+)
+
+pkg_files(
+    name = "proto_srcs",
+    srcs = [
+        ":color_cs",
+        ":render_data_cs",
+    ],
+    prefix = "Util",
+)
+
+csharp_proto_src(
+    name = "color_cs",
+    proto_src = "mediapipe/util/color.proto",
+    deps = [
+        "@com_google_mediapipe//mediapipe/util:protos_src",
+    ],
+)
+
+csharp_proto_src(
+    name = "render_data_cs",
+    proto_src = "mediapipe/util/render_data.proto",
+    deps = [
+        "@com_google_mediapipe//mediapipe/util:protos_src",
+    ],
 )

--- a/third_party/mediapipe_visibility.diff
+++ b/third_party/mediapipe_visibility.diff
@@ -1,8 +1,22 @@
+diff --git a/mediapipe/calculators/tensor/BUILD b/mediapipe/calculators/tensor/BUILD
+index 72c2f51..f400da5 100644
+--- a/mediapipe/calculators/tensor/BUILD
++++ b/mediapipe/calculators/tensor/BUILD
+@@ -886,3 +886,9 @@ cc_library(
+     }),
+     alwayslink = 1,
+ )
++
++filegroup(
++    name = "protos_src",
++    srcs = glob(["*.proto"]),
++    visibility = ["//visibility:public"],
++)
 diff --git a/mediapipe/framework/BUILD b/mediapipe/framework/BUILD
-index c25e9d8..d1de343 100644
+index ef32c6c..75f56fb 100644
 --- a/mediapipe/framework/BUILD
 +++ b/mediapipe/framework/BUILD
-@@ -1676,5 +1676,5 @@ cc_test(
+@@ -1666,5 +1666,5 @@ cc_test(
  filegroup(
      name = "protos_src",
      srcs = glob(["*.proto"]),
@@ -10,10 +24,10 @@ index c25e9d8..d1de343 100644
 +    visibility = ["//visibility:public"],
  )
 diff --git a/mediapipe/framework/formats/BUILD b/mediapipe/framework/formats/BUILD
-index e0ec40e..7620d71 100644
+index f79e6aa..546750c 100644
 --- a/mediapipe/framework/formats/BUILD
 +++ b/mediapipe/framework/formats/BUILD
-@@ -276,7 +276,7 @@ mediapipe_register_type(
+@@ -310,7 +310,7 @@ mediapipe_register_type(
  filegroup(
      name = "protos_src",
      srcs = glob(["*.proto"]),
@@ -109,10 +123,10 @@ index 48b7b66..2d53a28 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/modules/objectron/calculators/BUILD b/mediapipe/modules/objectron/calculators/BUILD
-index 66150c5..7ab59ce 100644
+index fb75eb3..92b306d 100644
 --- a/mediapipe/modules/objectron/calculators/BUILD
 +++ b/mediapipe/modules/objectron/calculators/BUILD
-@@ -387,3 +387,9 @@ cc_test(
+@@ -405,3 +405,9 @@ cc_test(
          "@com_google_absl//absl/container:flat_hash_set",
      ],
  )

--- a/third_party/mediapipe_visibility.diff
+++ b/third_party/mediapipe_visibility.diff
@@ -12,6 +12,20 @@ index 72c2f51..f400da5 100644
 +    srcs = glob(["*.proto"]),
 +    visibility = ["//visibility:public"],
 +)
+diff --git a/mediapipe/calculators/util/BUILD b/mediapipe/calculators/util/BUILD
+index 0c1a3ce..13b887a 100644
+--- a/mediapipe/calculators/util/BUILD
++++ b/mediapipe/calculators/util/BUILD
+@@ -1443,3 +1443,9 @@ cc_test(
+         "@com_google_absl//absl/strings",
+     ],
+ )
++
++filegroup(
++    name = "protos_src",
++    srcs = glob(["*.proto"]),
++    visibility = ["//visibility:public"],
++)
 diff --git a/mediapipe/framework/BUILD b/mediapipe/framework/BUILD
 index ef32c6c..75f56fb 100644
 --- a/mediapipe/framework/BUILD
@@ -128,6 +142,20 @@ index fb75eb3..92b306d 100644
 +++ b/mediapipe/modules/objectron/calculators/BUILD
 @@ -405,3 +405,9 @@ cc_test(
          "@com_google_absl//absl/container:flat_hash_set",
+     ],
+ )
++
++filegroup(
++    name = "protos_src",
++    srcs = glob(["*.proto"]),
++    visibility = ["//visibility:public"],
++)
+diff --git a/mediapipe/util/BUILD b/mediapipe/util/BUILD
+index a1b179a..741f767 100644
+--- a/mediapipe/util/BUILD
++++ b/mediapipe/util/BUILD
+@@ -343,3 +343,9 @@ cc_test(
+         "//mediapipe/framework/port:gtest_main",
      ],
  )
 +


### PR DESCRIPTION
related to #295 

- Port `TensorsToDetectionsCalculatorOptions` and `ThresholdingCalculatorOptions`
- Change `TensorsToDetectionsCalculatorOptions#MinScoreThresh` and `ThresholdingCalculatorOptions#Threshold` at runtime

To upgrade the installed plugin, you need to remove old scripts first and then build them again.
```sh
rm -rf build # or `python build.py clean`
python build.py uninstall
python build.py build ... # build native plugins and scripts again
```

Notes
1. `Mediapipe.Color` class is now included, which can conflict with `UnityEngine.Color`.
2. Currently, `Google.Protobuf.dll` needs to be compiled manually because the latest version still has a bug (cf. https://github.com/homuler/MediaPipeUnityPlugin/issues/295#issuecomment-1060785448).