### PR TITLE
fix(sample): Anchor position is flipped

### DIFF
--- a/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
@@ -24,7 +24,8 @@ namespace Mediapipe.Unity.InstantMotionTracking
         {
           if (RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, Input.mousePosition, Camera.main, out var localPoint))
           {
-            var normalizedPoint = rectTransform.GetNormalizedPosition(localPoint, graphRunner.rotation, ImageSourceProvider.ImageSource.isHorizontallyFlipped);
+            var isMirrored = ImageSourceProvider.ImageSource.isFrontFacing ^ ImageSourceProvider.ImageSource.isHorizontallyFlipped;
+            var normalizedPoint = rectTransform.GetNormalizedPosition(localPoint, graphRunner.rotation, isMirrored);
             graphRunner.ResetAnchor(normalizedPoint.x, normalizedPoint.y);
             _trackedAnchorDataAnnotationController.ResetAnchor();
           }


### PR DESCRIPTION
The anchor position in the Instant Motion Tracking Scene is flipped.