### PR TITLE
fix: check Packet types at compile-time more properly

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Core/MpResourceHandle.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Core/MpResourceHandle.cs
@@ -10,7 +10,19 @@ namespace Mediapipe
 {
   public abstract class MpResourceHandle : DisposableObject, IMpResourceHandle
   {
-    protected IntPtr ptr;
+    private IntPtr _ptr = IntPtr.Zero;
+    protected IntPtr ptr
+    {
+      get => _ptr;
+      set
+      {
+        if (value != IntPtr.Zero && OwnsResource())
+        {
+          throw new InvalidOperationException($"This object owns another resource");
+        }
+        _ptr = value;
+      }
+    }
 
     protected MpResourceHandle(bool isOwner = true) : this(IntPtr.Zero, isOwner) { }
 
@@ -40,7 +52,7 @@ namespace Mediapipe
 
     public bool OwnsResource()
     {
-      return isOwner && ptr != IntPtr.Zero;
+      return isOwner && IsResourcePresent();
     }
     #endregion
 
@@ -79,6 +91,11 @@ namespace Mediapipe
       UnsafeNativeMethods.delete_array__PKc(strPtr);
 
       return str;
+    }
+
+    protected bool IsResourcePresent()
+    {
+      return ptr != IntPtr.Zero;
     }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
@@ -79,14 +79,14 @@ namespace Mediapipe
       return new Status(statusPtr);
     }
 
-    public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, bool observeTimestampBounds, out GCHandle callbackHandle) where TPacket : Packet<TValue>
+    public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, bool observeTimestampBounds, out GCHandle callbackHandle) where TPacket : Packet<TValue>, new()
     {
       NativePacketCallback nativePacketCallback = (IntPtr _, IntPtr packetPtr) =>
       {
         Status status = null;
         try
         {
-          var packet = (TPacket)Activator.CreateInstance(typeof(TPacket), packetPtr, false);
+          var packet = Packet<TValue>.Create<TPacket>(packetPtr, false);
           status = packetCallback(packet);
         }
         catch (Exception e)
@@ -100,7 +100,7 @@ namespace Mediapipe
       return ObserveOutputStream(streamName, nativePacketCallback, observeTimestampBounds);
     }
 
-    public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, out GCHandle callbackHandle) where TPacket : Packet<TValue>
+    public Status ObserveOutputStream<TPacket, TValue>(string streamName, PacketCallback<TPacket, TValue> packetCallback, out GCHandle callbackHandle) where TPacket : Packet<TValue>, new()
     {
       return ObserveOutputStream(streamName, packetCallback, false, out callbackHandle);
     }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/Anchor3dVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/Anchor3dVectorPacket.cs
@@ -11,7 +11,11 @@ namespace Mediapipe
 {
   public class Anchor3dVectorPacket : Packet<List<Anchor3d>>
   {
-    public Anchor3dVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="Anchor3dVectorPacket" /> instance.
+    /// </summary>
+    public Anchor3dVectorPacket() : base(true) { }
+
     public Anchor3dVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
     public Anchor3dVectorPacket(Anchor3d[] value) : base()
@@ -25,6 +29,11 @@ namespace Mediapipe
       UnsafeNativeMethods.mp__MakeAnchor3dVectorPacket_At__PA_i_Rt(value, value.Length, timestamp.mpPtr, out var ptr).Assert();
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
+    }
+
+    public Anchor3dVectorPacket At(Timestamp timestamp)
+    {
+      return At<Anchor3dVectorPacket>(timestamp);
     }
 
     public override List<Anchor3d> Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/BoolPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/BoolPacket.cs
@@ -10,7 +10,10 @@ namespace Mediapipe
 {
   public class BoolPacket : Packet<bool>
   {
-    public BoolPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="BoolPacket" /> instance.
+    /// </summary>
+    public BoolPacket() : base(true) { }
 
     public BoolPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -25,6 +28,11 @@ namespace Mediapipe
       UnsafeNativeMethods.mp__MakeBoolPacket_At__b_Rt(value, timestamp.mpPtr, out var ptr).Assert();
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
+    }
+
+    public BoolPacket At(Timestamp timestamp)
+    {
+      return At<BoolPacket>(timestamp);
     }
 
     public override bool Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ClassificationListPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ClassificationListPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class ClassificationListPacket : Packet<ClassificationList>
   {
-    public ClassificationListPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="ClassificationListPacket" /> instance.
+    /// </summary>
+    public ClassificationListPacket() : base(true) { }
+
     public ClassificationListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public ClassificationListPacket At(Timestamp timestamp)
+    {
+      return At<ClassificationListPacket>(timestamp);
+    }
 
     public override ClassificationList Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ClassificationListVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ClassificationListVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class ClassificationListVectorPacket : Packet<List<ClassificationList>>
   {
-    public ClassificationListVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="ClassificationListVectorPacket" /> instance.
+    /// </summary>
+    public ClassificationListVectorPacket() : base(true) { }
+
     public ClassificationListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public ClassificationListVectorPacket At(Timestamp timestamp)
+    {
+      return At<ClassificationListVectorPacket>(timestamp);
+    }
 
     public override List<ClassificationList> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/DetectionPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/DetectionPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class DetectionPacket : Packet<Detection>
   {
-    public DetectionPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="DetectionPacket" /> instance.
+    /// </summary>
+    public DetectionPacket() : base(true) { }
+
     public DetectionPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public DetectionPacket At(Timestamp timestamp)
+    {
+      return At<DetectionPacket>(timestamp);
+    }
 
     public override Detection Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/DetectionVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/DetectionVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class DetectionVectorPacket : Packet<List<Detection>>
   {
-    public DetectionVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="DetectionVectorPacket" /> instance.
+    /// </summary>
+    public DetectionVectorPacket() : base(true) { }
+
     public DetectionVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public DetectionVectorPacket At(Timestamp timestamp)
+    {
+      return At<DetectionVectorPacket>(timestamp);
+    }
 
     public override List<Detection> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FaceGeometryPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FaceGeometryPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class FaceGeometryPacket : Packet<FaceGeometry.FaceGeometry>
   {
-    public FaceGeometryPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="FaceGeometryPacket" /> instance.
+    /// </summary>
+    public FaceGeometryPacket() : base(true) { }
+
     public FaceGeometryPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public FaceGeometryPacket At(Timestamp timestamp)
+    {
+      return At<FaceGeometryPacket>(timestamp);
+    }
 
     public override FaceGeometry.FaceGeometry Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FaceGeometryVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FaceGeometryVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class FaceGeometryVectorPacket : Packet<List<FaceGeometry.FaceGeometry>>
   {
-    public FaceGeometryVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="FaceGeometryVectorPacket" /> instance.
+    /// </summary>
+    public FaceGeometryVectorPacket() : base(true) { }
+
     public FaceGeometryVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public FaceGeometryVectorPacket At(Timestamp timestamp)
+    {
+      return At<FaceGeometryVectorPacket>(timestamp);
+    }
 
     public override List<FaceGeometry.FaceGeometry> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FloatArrayPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FloatArrayPacket.cs
@@ -26,7 +26,10 @@ namespace Mediapipe
       }
     }
 
-    public FloatArrayPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="FloatArrayPacket" /> instance.
+    /// </summary>
+    public FloatArrayPacket() : base(true) { }
 
     public FloatArrayPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -43,6 +46,11 @@ namespace Mediapipe
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
       length = value.Length;
+    }
+
+    public FloatArrayPacket At(Timestamp timestamp)
+    {
+      return At<FloatArrayPacket>(timestamp);
     }
 
     public override float[] Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FloatPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FloatPacket.cs
@@ -10,7 +10,10 @@ namespace Mediapipe
 {
   public class FloatPacket : Packet<float>
   {
-    public FloatPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="FloatPacket" /> instance.
+    /// </summary>
+    public FloatPacket() : base(true) { }
 
     public FloatPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -25,6 +28,11 @@ namespace Mediapipe
       UnsafeNativeMethods.mp__MakeFloatPacket_At__f_Rt(value, timestamp.mpPtr, out var ptr).Assert();
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
+    }
+
+    public FloatPacket At(Timestamp timestamp)
+    {
+      return At<FloatPacket>(timestamp);
     }
 
     public override float Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FrameAnnotationPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/FrameAnnotationPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class FrameAnnotationPacket : Packet<FrameAnnotation>
   {
-    public FrameAnnotationPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="FrameAnnotationPacket" /> instance.
+    /// </summary>
+    public FrameAnnotationPacket() : base(true) { }
+
     public FrameAnnotationPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public FrameAnnotationPacket At(Timestamp timestamp)
+    {
+      return At<FrameAnnotationPacket>(timestamp);
+    }
 
     public override FrameAnnotation Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/GpuBufferPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/GpuBufferPacket.cs
@@ -10,7 +10,11 @@ namespace Mediapipe
 {
   public class GpuBufferPacket : Packet<GpuBuffer>
   {
-    public GpuBufferPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="GpuBufferPacket" /> instance.
+    /// </summary>
+    public GpuBufferPacket() : base(true) { }
+
     public GpuBufferPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
     public GpuBufferPacket(GpuBuffer gpuBuffer) : base()
@@ -28,6 +32,11 @@ namespace Mediapipe
       gpuBuffer.Dispose(); // respect move semantics
 
       this.ptr = ptr;
+    }
+
+    public GpuBufferPacket At(Timestamp timestamp)
+    {
+      return At<GpuBufferPacket>(timestamp);
     }
 
     public override GpuBuffer Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ImageFramePacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/ImageFramePacket.cs
@@ -10,7 +10,10 @@ namespace Mediapipe
 {
   public class ImageFramePacket : Packet<ImageFrame>
   {
-    public ImageFramePacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="ImageFramePacket" /> instance.
+    /// </summary>
+    public ImageFramePacket() : base(true) { }
 
     public ImageFramePacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -29,6 +32,11 @@ namespace Mediapipe
       imageFrame.Dispose(); // respect move semantics
 
       this.ptr = ptr;
+    }
+
+    public ImageFramePacket At(Timestamp timestamp)
+    {
+      return At<ImageFramePacket>(timestamp);
     }
 
     public override ImageFrame Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/IntPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/IntPacket.cs
@@ -10,7 +10,10 @@ namespace Mediapipe
 {
   public class IntPacket : Packet<int>
   {
-    public IntPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="IntPacket" /> instance.
+    /// </summary>
+    public IntPacket() : base(true) { }
 
     public IntPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -25,6 +28,11 @@ namespace Mediapipe
       UnsafeNativeMethods.mp__MakeIntPacket_At__i_Rt(value, timestamp.mpPtr, out var ptr).Assert();
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
+    }
+
+    public IntPacket At(Timestamp timestamp)
+    {
+      return At<IntPacket>(timestamp);
     }
 
     public override int Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/LandmarkListPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/LandmarkListPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class LandmarkListPacket : Packet<LandmarkList>
   {
-    public LandmarkListPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="LandmarkListPacket" /> instance.
+    /// </summary>
+    public LandmarkListPacket() : base(true) { }
+
     public LandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public LandmarkListPacket At(Timestamp timestamp)
+    {
+      return At<LandmarkListPacket>(timestamp);
+    }
 
     public override LandmarkList Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/LandmarkListVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/LandmarkListVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class LandmarkListVectorPacket : Packet<List<LandmarkList>>
   {
-    public LandmarkListVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="LandmarkListVectorPacket" /> instance.
+    /// </summary>
+    public LandmarkListVectorPacket() : base(true) { }
+
     public LandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public LandmarkListVectorPacket At(Timestamp timestamp)
+    {
+      return At<LandmarkListVectorPacket>(timestamp);
+    }
 
     public override List<LandmarkList> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedLandmarkListPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedLandmarkListPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class NormalizedLandmarkListPacket : Packet<NormalizedLandmarkList>
   {
-    public NormalizedLandmarkListPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="NormalizedLandmarkListPacket" /> instance.
+    /// </summary>
+    public NormalizedLandmarkListPacket() : base(true) { }
+
     public NormalizedLandmarkListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public NormalizedLandmarkListPacket At(Timestamp timestamp)
+    {
+      return At<NormalizedLandmarkListPacket>(timestamp);
+    }
 
     public override NormalizedLandmarkList Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedLandmarkListVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class NormalizedLandmarkListVectorPacket : Packet<List<NormalizedLandmarkList>>
   {
-    public NormalizedLandmarkListVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="NormalizedLandmarkListVectorPacket" /> instance.
+    /// </summary>
+    public NormalizedLandmarkListVectorPacket() : base(true) { }
+
     public NormalizedLandmarkListVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public NormalizedLandmarkListVectorPacket At(Timestamp timestamp)
+    {
+      return At<NormalizedLandmarkListVectorPacket>(timestamp);
+    }
 
     public override List<NormalizedLandmarkList> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedRectPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedRectPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class NormalizedRectPacket : Packet<NormalizedRect>
   {
-    public NormalizedRectPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="NormalizedRectPacket" /> instance.
+    /// </summary>
+    public NormalizedRectPacket() : base(true) { }
+
     public NormalizedRectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public NormalizedRectPacket At(Timestamp timestamp)
+    {
+      return At<NormalizedRectPacket>(timestamp);
+    }
 
     public override NormalizedRect Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedRectVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/NormalizedRectVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class NormalizedRectVectorPacket : Packet<List<NormalizedRect>>
   {
-    public NormalizedRectVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="NormalizedRectVectorPacket" /> instance.
+    /// </summary>
+    public NormalizedRectVectorPacket() : base(true) { }
+
     public NormalizedRectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public NormalizedRectVectorPacket At(Timestamp timestamp)
+    {
+      return At<NormalizedRectVectorPacket>(timestamp);
+    }
 
     public override List<NormalizedRect> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/RectPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/RectPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class RectPacket : Packet<Rect>
   {
-    public RectPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="RectPacket" /> instance.
+    /// </summary>
+    public RectPacket() : base(true) { }
+
     public RectPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public RectPacket At(Timestamp timestamp)
+    {
+      return At<RectPacket>(timestamp);
+    }
 
     public override Rect Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/RectVectorPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/RectVectorPacket.cs
@@ -11,8 +11,17 @@ namespace Mediapipe
 {
   public class RectVectorPacket : Packet<List<Rect>>
   {
-    public RectVectorPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="RectVectorPacket" /> instance.
+    /// </summary>
+    public RectVectorPacket() : base(true) { }
+
     public RectVectorPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public RectVectorPacket At(Timestamp timestamp)
+    {
+      return At<RectVectorPacket>(timestamp);
+    }
 
     public override List<Rect> Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/SidePacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/SidePacket.cs
@@ -23,9 +23,11 @@ namespace Mediapipe
 
     public int size => SafeNativeMethods.mp_SidePacket__size(mpPtr);
 
-    /// TODO: force T to be Packet
-    /// <remarks>Make sure that the type of the returned packet value is correct</remarks>
-    public T At<T>(string key)
+    /// <remarks>
+    ///   This method cannot verify that the packet type corresponding to the <paramref name="key" /> is indeed a <typeparamref name="TPacket" />,
+    ///   so you must make sure by youreself that it is.
+    /// </remarks>
+    public TPacket At<TPacket, TValue>(string key) where TPacket : Packet<TValue>, new()
     {
       UnsafeNativeMethods.mp_SidePacket__at__PKc(mpPtr, key, out var packetPtr).Assert();
 
@@ -33,9 +35,8 @@ namespace Mediapipe
       {
         return default; // null
       }
-
       GC.KeepAlive(this);
-      return (T)Activator.CreateInstance(typeof(T), packetPtr, true);
+      return Packet<TValue>.Create<TPacket>(packetPtr, true);
     }
 
     public void Emplace<T>(string key, Packet<T> packet)

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/StringPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/StringPacket.cs
@@ -11,7 +11,10 @@ namespace Mediapipe
 {
   public class StringPacket : Packet<string>
   {
-    public StringPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="StringPacket" /> instance.
+    /// </summary>
+    public StringPacket() : base(true) { }
 
     public StringPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
 
@@ -39,6 +42,11 @@ namespace Mediapipe
       UnsafeNativeMethods.mp__MakeStringPacket_At__PKc_i_Rt(bytes, bytes.Length, timestamp.mpPtr, out var ptr).Assert();
       GC.KeepAlive(timestamp);
       this.ptr = ptr;
+    }
+
+    public StringPacket At(Timestamp timestamp)
+    {
+      return At<StringPacket>(timestamp);
     }
 
     public override string Get()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/TimedModelMatrixProtoListPacket.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet/TimedModelMatrixProtoListPacket.cs
@@ -10,8 +10,17 @@ namespace Mediapipe
 {
   public class TimedModelMatrixProtoListPacket : Packet<TimedModelMatrixProtoList>
   {
-    public TimedModelMatrixProtoListPacket() : base() { }
+    /// <summary>
+    ///   Creates an empty <see cref="TimedModelMatrixProtoListPacket" /> instance.
+    /// </summary>
+    public TimedModelMatrixProtoListPacket() : base(true) { }
+
     public TimedModelMatrixProtoListPacket(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }
+
+    public TimedModelMatrixProtoListPacket At(Timestamp timestamp)
+    {
+      return At<TimedModelMatrixProtoListPacket>(timestamp);
+    }
 
     public override TimedModelMatrixProtoList Get()
     {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
@@ -84,6 +84,28 @@ namespace Tests
     }
     #endregion
 
+    #region #At
+    [Test]
+    public void At_ShouldReturnNewPacketWithTimestamp()
+    {
+      using (var timestamp = new Timestamp(1))
+      {
+        var packet = new BoolPacket(true).At(timestamp);
+        Assert.True(packet.Get());
+        Assert.AreEqual(packet.Timestamp(), timestamp);
+
+        using (var newTimestamp = new Timestamp(2))
+        {
+          var newPacket = packet.At(newTimestamp);
+          Assert.True(newPacket.Get());
+          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+        }
+
+        Assert.True(packet.isDisposed);
+      }
+    }
+    #endregion
+
     #region #Consume
     [Test]
     public void Consume_ShouldThrowNotSupportedException()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
@@ -87,6 +87,29 @@ namespace Tests
     }
     #endregion
 
+    #region #At
+    [Test]
+    public void At_ShouldReturnNewPacketWithTimestamp()
+    {
+      using (var timestamp = new Timestamp(1))
+      {
+        float[] array = { 0.0f };
+        var packet = new FloatArrayPacket(array).At(timestamp);
+        Assert.AreEqual(packet.Get(), array);
+        Assert.AreEqual(packet.Timestamp(), timestamp);
+
+        using (var newTimestamp = new Timestamp(2))
+        {
+          var newPacket = packet.At(newTimestamp);
+          Assert.AreEqual(newPacket.Get(), array);
+          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+        }
+
+        Assert.True(packet.isDisposed);
+      }
+    }
+    #endregion
+
     #region #Consume
     [Test]
     public void Consume_ShouldThrowNotSupportedException()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
@@ -72,6 +72,28 @@ namespace Tests
     }
     #endregion
 
+    #region #At
+    [Test]
+    public void At_ShouldReturnNewPacketWithTimestamp()
+    {
+      using (var timestamp = new Timestamp(1))
+      {
+        var packet = new FloatPacket(0).At(timestamp);
+        Assert.AreEqual(packet.Get(), 0.0f);
+        Assert.AreEqual(packet.Timestamp(), timestamp);
+
+        using (var newTimestamp = new Timestamp(2))
+        {
+          var newPacket = packet.At(newTimestamp);
+          Assert.AreEqual(newPacket.Get(), 0.0f);
+          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+        }
+
+        Assert.True(packet.isDisposed);
+      }
+    }
+    #endregion
+
     #region #Consume
     [Test]
     public void Consume_ShouldThrowNotSupportedException()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
@@ -96,6 +96,28 @@ namespace Tests
     }
     #endregion
 
+    #region #At
+    [Test]
+    public void At_ShouldReturnNewPacketWithTimestamp()
+    {
+      using (var timestamp = new Timestamp(1))
+      {
+        var packet = new ImageFramePacket(new ImageFrame(ImageFormat.Format.SRGBA, 10, 10)).At(timestamp);
+        Assert.AreEqual(packet.Get().Width(), 10);
+        Assert.AreEqual(packet.Timestamp(), timestamp);
+
+        using (var newTimestamp = new Timestamp(2))
+        {
+          var newPacket = packet.At(newTimestamp);
+          Assert.AreEqual(newPacket.Get().Width(), 10);
+          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+        }
+
+        Assert.True(packet.isDisposed);
+      }
+    }
+    #endregion
+
     #region #Get
     [Test, SignalAbort]
     public void Get_ShouldThrowMediaPipeException_When_DataIsEmpty()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
@@ -11,29 +11,6 @@ namespace Tests
 {
   public class PacketTest
   {
-    #region #At
-    [Test]
-    public void At_ShouldReturnNewPacketWithTimestamp()
-    {
-      using (var timestamp = new Timestamp(1))
-      {
-        var packet = new BoolPacket(true).At(timestamp);
-        Assert.True(packet.Get());
-        Assert.AreEqual(packet.Timestamp(), timestamp);
-
-        using (var newTimestamp = new Timestamp(2))
-        {
-          var newPacket = packet.At(newTimestamp);
-          Assert.IsInstanceOf<BoolPacket>(newPacket);
-          Assert.True(newPacket.Get());
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
-        }
-
-        Assert.True(packet.isDisposed);
-      }
-    }
-    #endregion
-
     #region #DebugString
     [Test]
     public void DebugString_ShouldReturnDebugString_When_InstantiatedWithDefaultConstructor()

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
@@ -29,8 +29,7 @@ namespace Tests
           Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
         }
 
-        Assert.True(packet.Get());
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.True(packet.isDisposed);
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
@@ -45,13 +45,13 @@ namespace Tests
       using (var sidePacket = new SidePacket())
       {
         Assert.AreEqual(sidePacket.size, 0);
-        Assert.IsNull(sidePacket.At<FloatPacket>("value"));
+        Assert.IsNull(sidePacket.At<FloatPacket, float>("value"));
 
         var flagPacket = new FloatPacket(1.0f);
         sidePacket.Emplace("value", flagPacket);
 
         Assert.AreEqual(sidePacket.size, 1);
-        Assert.AreEqual(sidePacket.At<FloatPacket>("value").Get(), 1.0f);
+        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
         Assert.True(flagPacket.isDisposed);
       }
     }
@@ -63,11 +63,11 @@ namespace Tests
       {
         var oldValuePacket = new FloatPacket(1.0f);
         sidePacket.Emplace("value", oldValuePacket);
-        Assert.AreEqual(sidePacket.At<FloatPacket>("value").Get(), 1.0f);
+        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
 
         var newValuePacket = new FloatPacket(2.0f);
         sidePacket.Emplace("value", newValuePacket);
-        Assert.AreEqual(sidePacket.At<FloatPacket>("value").Get(), 1.0f);
+        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
@@ -99,6 +99,29 @@ namespace Tests
     }
     #endregion
 
+    #region #At
+    [Test]
+    public void At_ShouldReturnNewPacketWithTimestamp()
+    {
+      using (var timestamp = new Timestamp(1))
+      {
+        var str = "str";
+        var packet = new StringPacket(str).At(timestamp);
+        Assert.AreEqual(packet.Get(), str);
+        Assert.AreEqual(packet.Timestamp(), timestamp);
+
+        using (var newTimestamp = new Timestamp(2))
+        {
+          var newPacket = packet.At(newTimestamp);
+          Assert.AreEqual(newPacket.Get(), str);
+          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+        }
+
+        Assert.True(packet.isDisposed);
+      }
+    }
+    #endregion
+
     #region #GetByteArray
     [Test]
     public void GetByteArray_ShouldReturnByteArray()


### PR DESCRIPTION
- `Packet#At` without type parameters
- `SidePacket#At` with type checks
- fix memory leaks caused by Packet constructors
- BREAKING: `Packet#At` disposes of the receiver object