### PR TITLE
fix: ignore ImageSource#isVerticallyFlipped in synchronous mode

### DIFF
--- a/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationGraph.cs
+++ b/Assets/Mediapipe/Samples/Scenes/Hair Segmentation/HairSegmentationGraph.cs
@@ -83,7 +83,7 @@ namespace Mediapipe.Unity.HairSegmentation
       var isInverted = CoordinateSystem.ImageCoordinate.IsInverted(imageSource.rotation);
       var outputRotation = imageSource.rotation;
       var outputHorizontallyFlipped = !isInverted && imageSource.isHorizontallyFlipped;
-      var outputVerticallyFlipped = imageSource.isVerticallyFlipped ^ (isInverted && imageSource.isHorizontallyFlipped);
+      var outputVerticallyFlipped = (!runningMode.IsSynchronous() && imageSource.isVerticallyFlipped) ^ (isInverted && imageSource.isHorizontallyFlipped);
 
       if ((outputHorizontallyFlipped && outputVerticallyFlipped) || outputRotation == RotationAngle.Rotation180)
       {


### PR DESCRIPTION
The orientation of the hair mask is wrong when running in synchronous mode.