### PR TITLE
fix: constructor should throw if it fails to initialize

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
@@ -22,19 +22,15 @@ namespace Mediapipe
       this.ptr = ptr;
     }
 
-    public CalculatorGraph(string textFormatConfig) : base()
-    {
-      UnsafeNativeMethods.mp_CalculatorGraph__PKc(textFormatConfig, out var ptr).Assert();
-      this.ptr = ptr;
-    }
-
-    public CalculatorGraph(byte[] serializedConfig) : base()
+    private CalculatorGraph(byte[] serializedConfig) : base()
     {
       UnsafeNativeMethods.mp_CalculatorGraph__PKc_i(serializedConfig, serializedConfig.Length, out var ptr).Assert();
       this.ptr = ptr;
     }
 
     public CalculatorGraph(CalculatorGraphConfig config) : this(config.ToByteArray()) { }
+
+    public CalculatorGraph(string textFormatConfig) : this(CalculatorGraphConfig.Parser.ParseFromTextFormat(textFormatConfig)) { }
 
     protected override void DeleteMpPtr()
     {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraphConfigExtension.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraphConfigExtension.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 homuler
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+using pb = Google.Protobuf;
+
+namespace Mediapipe
+{
+  public static class CalculatorGraphConfigExtension
+  {
+    public static CalculatorGraphConfig ParseFromTextFormat(this pb::MessageParser<CalculatorGraphConfig> _, string configText)
+    {
+      if (UnsafeNativeMethods.mp_api__ConvertFromCalculatorGraphConfigTextFormat(configText, out var serializedProto))
+      {
+        var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
+        serializedProto.Dispose();
+        return config;
+      }
+      throw new MediaPipeException("Failed to parse config text. See error logs for more details");
+    }
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraphConfigExtension.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraphConfigExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d17ea3a25da1d9e79b6121a228e2a99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/CalculatorGraph_Unsafe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/CalculatorGraph_Unsafe.cs
@@ -15,9 +15,6 @@ namespace Mediapipe
     public static extern MpReturnCode mp_CalculatorGraph__(out IntPtr graph);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
-    public static extern MpReturnCode mp_CalculatorGraph__PKc(string textFormatConfig, out IntPtr graph);
-
-    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern MpReturnCode mp_CalculatorGraph__PKc_i(byte[] serializedConfig, int size, out IntPtr graph);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Extension/CalculatorGraphConfigExtension.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Extension/CalculatorGraphConfigExtension.cs
@@ -10,17 +10,6 @@ namespace Mediapipe.Unity
 {
   public static class CalculatorGraphConfigExtension
   {
-    public static CalculatorGraphConfig ParseFromTextFormat(this pb::MessageParser<CalculatorGraphConfig> _, string configText)
-    {
-      if (UnsafeNativeMethods.mp_api__ConvertFromCalculatorGraphConfigTextFormat(configText, out var serializedProto))
-      {
-        var config = serializedProto.Deserialize(CalculatorGraphConfig.Parser);
-        serializedProto.Dispose();
-        return config;
-      }
-      throw new MediaPipeException("Failed to parse config text. See error logs for more details");
-    }
-
     public static string AddPacketPresenceCalculator(this CalculatorGraphConfig config, string outputStreamName)
     {
       var presenceStreamName = Tool.GetUnusedStreamName(config, $"{outputStreamName}_presence");

--- a/mediapipe_api/framework/calculator_graph.cc
+++ b/mediapipe_api/framework/calculator_graph.cc
@@ -24,15 +24,6 @@ MpReturnCode mp_CalculatorGraph__(mediapipe::CalculatorGraph** graph_out) {
 
 void mp_CalculatorGraph__delete(mediapipe::CalculatorGraph* graph) { delete graph; }
 
-MpReturnCode mp_CalculatorGraph__PKc(const char* text_format_config, mediapipe::CalculatorGraph** graph_out) {
-  TRY_ALL
-    mediapipe::CalculatorGraphConfig config;
-    auto result = google::protobuf::TextFormat::ParseFromString(text_format_config, &config);
-    *graph_out = result ? new mediapipe::CalculatorGraph(config) : nullptr;
-    RETURN_CODE(MpReturnCode::Success);
-  CATCH_ALL
-}
-
 MpReturnCode mp_CalculatorGraph__PKc_i(const char* serialized_config, int size, mediapipe::CalculatorGraph** graph_out) {
   TRY_ALL
     auto config = ParseFromStringAsCalculatorGraphConfig(serialized_config, size);

--- a/mediapipe_api/framework/calculator_graph.h
+++ b/mediapipe_api/framework/calculator_graph.h
@@ -29,7 +29,6 @@ typedef std::map<std::string, mediapipe::Packet> SidePackets;
 typedef absl::Status* NativePacketCallback(mediapipe::CalculatorGraph* graph, int stream_id, const mediapipe::Packet&);
 
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__(mediapipe::CalculatorGraph** graph_out);
-MP_CAPI(MpReturnCode) mp_CalculatorGraph__PKc(const char* text_format_config, mediapipe::CalculatorGraph** graph_out);
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__PKc_i(const char* serialized_config, int size, mediapipe::CalculatorGraph** graph_out);
 MP_CAPI(void) mp_CalculatorGraph__delete(mediapipe::CalculatorGraph* graph);
 


### PR DESCRIPTION
`CalculatorGraph(string)` cannot initialize an instance if the given config format is invalid, but does not throw currently.

When some instance method is invoked after, it will trigger `SIGSEGV` and crash the whole application.
