### PR TITLE
fix: Enumerator can be invalid when an item is deleted

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/GlobalInstanceTable.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/GlobalInstanceTable.cs
@@ -81,7 +81,7 @@ namespace Mediapipe.Unity
     {
       lock (((ICollection)_table).SyncRoot)
       {
-        var deadKeys = _table.Where(x => !x.Value.TryGetTarget(out var target)).Select(x => x.Key);
+        var deadKeys = _table.Where(x => !x.Value.TryGetTarget(out var target)).Select(x => x.Key).ToArray();
 
         foreach (var key in deadKeys)
         {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
@@ -470,7 +470,7 @@ namespace Mediapipe.Unity
     {
       lock (((ICollection)_CallbackStatus).SyncRoot)
       {
-        var deadKeys = _CallbackStatus.Where(x => !_InstanceTable.ContainsKey(x.Key)).Select(x => x.Key);
+        var deadKeys = _CallbackStatus.Where(x => !_InstanceTable.ContainsKey(x.Key)).Select(x => x.Key).ToArray();
 
         foreach (var key in deadKeys)
         {


### PR DESCRIPTION
Fix a bug introduced by #563.

All the removing items must be enumerated before.