### PR TITLE
refactor!: coordinate transform and other helper methods

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Scenes/Instant Motion Tracking/Anchor3dAnnotation.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Instant Motion Tracking/Anchor3dAnnotation.cs
@@ -53,7 +53,7 @@ namespace Mediapipe.Unity
       if (ActivateFor(target))
       {
         var anchor3d = (Anchor3d)target;
-        var anchor2dPosition = GetAnnotationLayer().GetLocalPosition(anchor3d, rotationAngle, isMirrored);
+        var anchor2dPosition = GetScreenRect().GetPoint(anchor3d, rotationAngle, isMirrored);
         var anchor3dPosition = GetAnchorPositionInRay(anchor2dPosition, anchor3d.z * defaultDepth, cameraPosition);
 
         _pointAnnotation.Draw(anchor2dPosition);

--- a/Assets/MediaPipeUnity/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Instant Motion Tracking/InstantMotionTrackingSolution.cs
@@ -26,7 +26,7 @@ namespace Mediapipe.Unity.InstantMotionTracking
           if (RectTransformUtility.ScreenPointToLocalPointInRectangle(rectTransform, Input.mousePosition, Camera.main, out var localPoint))
           {
             var isMirrored = ImageSourceProvider.ImageSource.isFrontFacing ^ ImageSourceProvider.ImageSource.isHorizontallyFlipped;
-            var normalizedPoint = rectTransform.GetNormalizedPosition(localPoint, graphRunner.rotation, isMirrored);
+            var normalizedPoint = rectTransform.rect.PointToImageNormalized(localPoint, graphRunner.rotation, isMirrored);
             graphRunner.ResetAnchor(normalizedPoint.x, normalizedPoint.y);
             _trackedAnchorDataAnnotationController.ResetAnchor();
           }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionAnnotation.cs
@@ -65,7 +65,7 @@ namespace Mediapipe.Unity
 
         // Assume that location data's format is always RelativeBoundingBox
         // TODO: fix if there are cases where this assumption is not correct.
-        var rectVertices = GetAnnotationLayer().GetRectVertices(target.LocationData.RelativeBoundingBox, rotationAngle, isMirrored);
+        var rectVertices = GetScreenRect().GetRectVertices(target.LocationData.RelativeBoundingBox, rotationAngle, isMirrored);
         _locationDataAnnotation.SetColor(GetColor(score, Mathf.Clamp(threshold, 0.0f, 1.0f)));
         _locationDataAnnotation.Draw(rectVertices);
 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HierarchicalAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HierarchicalAnnotation.cs
@@ -13,6 +13,7 @@ namespace Mediapipe.Unity
     IHierachicalAnnotation root { get; }
     Transform transform { get; }
     RectTransform GetAnnotationLayer();
+    UnityEngine.Rect GetScreenRect();
   }
 
   public abstract class HierarchicalAnnotation : MonoBehaviour, IHierachicalAnnotation
@@ -35,6 +36,11 @@ namespace Mediapipe.Unity
     public RectTransform GetAnnotationLayer()
     {
       return root.transform.parent.gameObject.GetComponent<RectTransform>();
+    }
+
+    public UnityEngine.Rect GetScreenRect()
+    {
+      return GetAnnotationLayer().rect;
     }
 
     public bool isActive => gameObject.activeSelf;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/IrisLandmarkListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/IrisLandmarkListAnnotation.cs
@@ -65,13 +65,13 @@ namespace Mediapipe.Unity
       {
         _landmarkListAnnotation.Draw(target, visualizeZ);
 
-        var rectTransform = GetAnnotationLayer();
-        var center = rectTransform.GetLocalPosition(target[0], rotationAngle, isMirrored);
+        var rect = GetScreenRect();
+        var center = rect.GetPoint(target[0], rotationAngle, isMirrored);
         if (!visualizeZ)
         {
           center.z = 0.0f;
         }
-        var radius = CalculateRadius(rectTransform, target);
+        var radius = CalculateRadius(rect, target);
         _circleAnnotation.Draw(center, radius, vertices);
       }
     }
@@ -81,17 +81,17 @@ namespace Mediapipe.Unity
       Draw(target?.Landmark, visualizeZ, vertices);
     }
 
-    private float CalculateRadius(RectTransform rectTransform, IList<NormalizedLandmark> target)
+    private float CalculateRadius(UnityEngine.Rect rect, IList<NormalizedLandmark> target)
     {
-      var r1 = CalculateDistance(rectTransform, target[1], target[3]);
-      var r2 = CalculateDistance(rectTransform, target[2], target[4]);
+      var r1 = CalculateDistance(rect, target[1], target[3]);
+      var r2 = CalculateDistance(rect, target[2], target[4]);
       return (r1 + r2) / 4;
     }
 
-    private float CalculateDistance(RectTransform rectTransform, NormalizedLandmark a, NormalizedLandmark b)
+    private float CalculateDistance(UnityEngine.Rect rect, NormalizedLandmark a, NormalizedLandmark b)
     {
-      var aPos = rectTransform.GetLocalPosition(a, rotationAngle, isMirrored);
-      var bPos = rectTransform.GetLocalPosition(b, rotationAngle, isMirrored);
+      var aPos = rect.GetPoint(a, rotationAngle, isMirrored);
+      var bPos = rect.GetPoint(b, rotationAngle, isMirrored);
       aPos.z = 0.0f;
       bPos.z = 0.0f;
       return Vector3.Distance(aPos, bPos);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
@@ -53,7 +53,7 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        var position = GetAnnotationLayer().GetLocalPosition(target, scale, rotationAngle, isMirrored);
+        var position = GetScreenRect().GetPoint(target, scale, rotationAngle, isMirrored);
         if (!visualizeZ)
         {
           position.z = 0.0f;
@@ -88,7 +88,7 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        var position = GetAnnotationLayer().GetLocalPosition(target, focalLength, principalPoint, zScale, rotationAngle, isMirrored);
+        var position = GetScreenRect().GetPoint(target, focalLength, principalPoint, zScale, rotationAngle, isMirrored);
         if (!visualizeZ)
         {
           position.z = 0.0f;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PointAnnotation.cs
@@ -66,7 +66,7 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        var position = GetAnnotationLayer().GetLocalPosition(target, rotationAngle, isMirrored);
+        var position = GetScreenRect().GetPoint(target, rotationAngle, isMirrored);
         if (!visualizeZ)
         {
           position.z = 0.0f;
@@ -79,7 +79,7 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        var position = GetAnnotationLayer().GetLocalPosition(target, rotationAngle, isMirrored);
+        var position = GetScreenRect().GetPoint(target, rotationAngle, isMirrored);
         transform.localPosition = position;
       }
     }
@@ -113,7 +113,7 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        Draw(GetAnnotationLayer().GetLocalPosition(target, rotationAngle, isMirrored));
+        Draw(GetScreenRect().GetPoint(target, rotationAngle, isMirrored));
         SetColor(GetColor(target.Score, threshold));
       }
     }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleAnnotation.cs
@@ -58,11 +58,11 @@ namespace Mediapipe.Unity
       _lineRenderer.SetPositions(positions ?? _EmptyPositions);
     }
 
-    public void Draw(Rect target, Vector2 imageSize)
+    public void Draw(Rect target, Vector2Int imageSize)
     {
       if (ActivateFor(target))
       {
-        Draw(GetAnnotationLayer().GetRectVertices(target, imageSize, rotationAngle, isMirrored));
+        Draw(GetScreenRect().GetRectVertices(target, imageSize, rotationAngle, isMirrored));
       }
     }
 
@@ -70,11 +70,11 @@ namespace Mediapipe.Unity
     {
       if (ActivateFor(target))
       {
-        Draw(GetAnnotationLayer().GetRectVertices(target, rotationAngle, isMirrored));
+        Draw(GetScreenRect().GetRectVertices(target, rotationAngle, isMirrored));
       }
     }
 
-    public void Draw(LocationData target, Vector2 imageSize)
+    public void Draw(LocationData target, Vector2Int imageSize)
     {
       if (ActivateFor(target))
       {
@@ -82,12 +82,12 @@ namespace Mediapipe.Unity
         {
           case mplt.Format.BoundingBox:
             {
-              Draw(GetAnnotationLayer().GetRectVertices(target.BoundingBox, imageSize, rotationAngle, isMirrored));
+              Draw(GetScreenRect().GetRectVertices(target.BoundingBox, imageSize, rotationAngle, isMirrored));
               break;
             }
           case mplt.Format.RelativeBoundingBox:
             {
-              Draw(GetAnnotationLayer().GetRectVertices(target.RelativeBoundingBox, rotationAngle, isMirrored));
+              Draw(GetScreenRect().GetRectVertices(target.RelativeBoundingBox, rotationAngle, isMirrored));
               break;
             }
           case mplt.Format.Global:
@@ -108,7 +108,7 @@ namespace Mediapipe.Unity
         {
           case mplt.Format.RelativeBoundingBox:
             {
-              Draw(GetAnnotationLayer().GetRectVertices(target.RelativeBoundingBox, rotationAngle, isMirrored));
+              Draw(GetScreenRect().GetRectVertices(target.RelativeBoundingBox, rotationAngle, isMirrored));
               break;
             }
           case mplt.Format.BoundingBox:

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleListAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/RectangleListAnnotation.cs
@@ -36,7 +36,7 @@ namespace Mediapipe.Unity
       ApplyLineWidth(_lineWidth);
     }
 
-    public void Draw(IList<Rect> targets, Vector2 imageSize)
+    public void Draw(IList<Rect> targets, Vector2Int imageSize)
     {
       if (ActivateFor(targets))
       {

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/TransformAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/TransformAnnotation.cs
@@ -38,34 +38,25 @@ namespace Mediapipe.Unity
     public void Draw(Quaternion rotation, Vector3 scale, bool visualizeZ = true)
     {
       var q = Quaternion.Euler(0, 0, -(int)rotationAngle);
-      DrawArrow(_xArrow, q * rotation * Vector3.right, scale.x, visualizeZ);
-      DrawArrow(_yArrow, q * rotation * Vector3.up, scale.y, visualizeZ);
-      DrawArrow(_zArrow, q * rotation * Vector3.forward, scale.z, visualizeZ);
+      DrawArrow(_xArrow, scale.y * (q * rotation * Vector3.right), visualizeZ);
+      DrawArrow(_yArrow, scale.y * (q * rotation * Vector3.up), visualizeZ);
+      DrawArrow(_zArrow, scale.z * (q * rotation * Vector3.forward), visualizeZ);
     }
 
     public void Draw(ObjectAnnotation target, Vector3 position, float arrowLengthScale = 1.0f, bool visualizeZ = true)
     {
       origin = position;
 
-      var isInverted = CameraCoordinate.IsInverted(rotationAngle);
-      var (xScale, yScale) = isInverted ? (target.Scale[1], target.Scale[0]) : (target.Scale[0], target.Scale[1]);
-      var zScale = target.Scale[2];
-      // convert from right-handed to left-handed
-      var isXReversed = CameraCoordinate.IsXReversed(rotationAngle, isMirrored);
-      var isYReversed = CameraCoordinate.IsYReversed(rotationAngle, isMirrored);
-      var rotation = target.Rotation;
-      var xDir = GetDirection(rotation[0], rotation[3], rotation[6], isXReversed, isYReversed, isInverted);
-      var yDir = GetDirection(rotation[1], rotation[4], rotation[7], isXReversed, isYReversed, isInverted);
-      var zDir = GetDirection(rotation[2], rotation[5], rotation[8], isXReversed, isYReversed, isInverted);
-      DrawArrow(_xArrow, xDir, (isMirrored ? -1 : 1) * arrowLengthScale * xScale, visualizeZ);
-      DrawArrow(_yArrow, yDir, arrowLengthScale * yScale, visualizeZ);
-      DrawArrow(_zArrow, zDir, -arrowLengthScale * zScale, visualizeZ);
+      var (xDir, yDir, zDir) = CameraCoordinate.GetDirections(target, rotationAngle, isMirrored);
+      DrawArrow(_xArrow, arrowLengthScale * xDir, visualizeZ);
+      DrawArrow(_yArrow, arrowLengthScale * yDir, visualizeZ);
+      DrawArrow(_zArrow, arrowLengthScale * zDir, visualizeZ);
     }
 
-    private void DrawArrow(Arrow arrow, Vector3 normalizedDirection, float scale, bool visualizeZ)
+    private void DrawArrow(Arrow arrow, Vector3 vec, bool visualizeZ)
     {
-      var direction = Mathf.Sign(scale) * normalizedDirection;
-      var magnitude = Mathf.Abs(scale);
+      var magnitude = vec.magnitude;
+      var direction = vec.normalized;
 
       if (!visualizeZ)
       {
@@ -75,12 +66,6 @@ namespace Mediapipe.Unity
       }
       arrow.direction = direction;
       arrow.magnitude = magnitude;
-    }
-
-    private Vector3 GetDirection(float x, float y, float z, bool isXReversed, bool isYReversed, bool isInverted)
-    {
-      var dir = isInverted ? new Vector3(y, x, z) : new Vector3(x, y, z);
-      return Vector3.Scale(dir, new Vector3(isXReversed ? -1 : 1, isYReversed ? -1 : 1, -1));
     }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/TransformAnnotation.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/TransformAnnotation.cs
@@ -38,7 +38,7 @@ namespace Mediapipe.Unity
     public void Draw(Quaternion rotation, Vector3 scale, bool visualizeZ = true)
     {
       var q = Quaternion.Euler(0, 0, -(int)rotationAngle);
-      DrawArrow(_xArrow, scale.y * (q * rotation * Vector3.right), visualizeZ);
+      DrawArrow(_xArrow, scale.x * (q * rotation * Vector3.right), visualizeZ);
       DrawArrow(_yArrow, scale.y * (q * rotation * Vector3.up), visualizeZ);
       DrawArrow(_zArrow, scale.z * (q * rotation * Vector3.forward), visualizeZ);
     }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
@@ -50,8 +50,8 @@ namespace Mediapipe.Unity.CoordinateSystem
     {
       var (ndcX, ndcY) = ((-focalLengthX * x / z) + principalX, (focalLengthY * y / z) + principalY);
       var (width, height) = (xMax - xMin, yMax - yMin);
-      var (pixelX, pixelY) = ((1 + ndcX) / 2.0f * width, (1 - ndcY) / 2.0f * height);
-      var (rectX, rectY) = IsInverted(imageRotation) ? (pixelY, pixelX) : (pixelX, pixelY);
+      var (nx, ny) = ((1 + ndcX) / 2.0f, (1 - ndcY) / 2.0f);
+      var (rectX, rectY) = IsInverted(imageRotation) ? (ny * width, nx * height) : (nx * width, ny * height);
       var localX = (IsXReversed(imageRotation, isMirrored) ? width - rectX : rectX) + xMin;
       var localY = (IsYReversed(imageRotation, isMirrored) ? height - rectY : rectY) + yMin;
       // Reverse the sign of Z because camera coordinate system is right-handed
@@ -232,10 +232,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     private static Vector3 GetXDir(ObjectAnnotation objectAnnotation, bool isXReversed, bool isYReversed, bool isInverted)
     {
       var points = objectAnnotation.Keypoints;
-      var v1 = GetDirection(points[5].Point3D, points[1].Point3D, isXReversed, isYReversed, isInverted).normalized;
-      var v2 = GetDirection(points[6].Point3D, points[2].Point3D, isXReversed, isYReversed, isInverted).normalized;
-      var v3 = GetDirection(points[7].Point3D, points[3].Point3D, isXReversed, isYReversed, isInverted).normalized;
-      var v4 = GetDirection(points[8].Point3D, points[4].Point3D, isXReversed, isYReversed, isInverted).normalized;
+      var v1 = GetDirection(points[1].Point3D, points[5].Point3D, isXReversed, isYReversed, isInverted).normalized;
+      var v2 = GetDirection(points[2].Point3D, points[6].Point3D, isXReversed, isYReversed, isInverted).normalized;
+      var v3 = GetDirection(points[3].Point3D, points[7].Point3D, isXReversed, isYReversed, isInverted).normalized;
+      var v4 = GetDirection(points[4].Point3D, points[8].Point3D, isXReversed, isYReversed, isInverted).normalized;
       return (v1 + v2 + v3 + v4) / 4;
     }
 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
@@ -20,42 +20,220 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <summary>
     ///   Convert from camera coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
     /// <param name="x">X in camera coordinates</param>
     /// <param name="y">Y in camera coordinates</param>
     /// <param name="z">Z in camera coordinates</param>
-    /// <param name="focalLength">Normalized focal lengths in image coordinates</param>
-    /// <param name="principalPoint">Normalized principal point in image coordinates</param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="focalLengthX">Normalized focal length X in NDC space</param>
+    /// <param name="focalLengthY">Normalized focal length Y in NDC space</param>
+    /// <param name="principalX">Normalized principal point X in NDC space</param>
+    /// <param name="principalY">Normalized principal point Y in NDC space</param>
     /// <param name="zScale">Ratio of Z values in camera coordinates to local coordinates in Unity</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(RectTransform rectTransform, float x, float y, float z, Vector2 focalLength, Vector2 principalPoint, float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 CameraToLocalPoint(float x, float y, float z, float xMin, float xMax, float yMin, float yMax,
+                                             float focalLengthX, float focalLengthY, float principalX, float principalY,
+                                             float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var pixelX = ((-focalLength.x * x / z) + principalPoint.x) / 2;
-      var pixelY = ((focalLength.y * y / z) + principalPoint.y) / 2;
+      var (ndcX, ndcY) = ((-focalLengthX * x / z) + principalX, (focalLengthY * y / z) + principalY);
+      var (width, height) = (xMax - xMin, yMax - yMin);
+      var (pixelX, pixelY) = ((1 + ndcX) / 2.0f * width, (1 - ndcY) / 2.0f * height);
+      var (rectX, rectY) = IsInverted(imageRotation) ? (pixelY, pixelX) : (pixelX, pixelY);
+      var localX = (IsXReversed(imageRotation, isMirrored) ? width - rectX : rectX) + xMin;
+      var localY = (IsYReversed(imageRotation, isMirrored) ? height - rectY : rectY) + yMin;
       // Reverse the sign of Z because camera coordinate system is right-handed
-      var rect = rectTransform.rect;
-      return RealWorldCoordinate.GetLocalPosition(pixelX, pixelY, -z, new Vector3(rect.width, rect.height, zScale), imageRotation, isMirrored);
+      var localZ = -z * zScale;
+
+      return new Vector3(localX, localY, localZ);
+    }
+
+    /// <summary>
+    ///   Convert from camera coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="x">X in camera coordinates</param>
+    /// <param name="y">Y in camera coordinates</param>
+    /// <param name="z">Z in camera coordinates</param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="focalLength">Normalized focal lengths in NDC space</param>
+    /// <param name="principalPoint">Normalized principal point in NDC space</param>
+    /// <param name="zScale">Ratio of Z values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 CameraToLocalPoint(float x, float y, float z, float xMin, float xMax, float yMin, float yMax, Vector2 focalLength, Vector2 principalPoint,
+                                             float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return CameraToLocalPoint(x, y, z, xMin, xMax, yMin, yMax, focalLength.x, focalLength.y, principalPoint.x, principalPoint.y, zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from camera coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="x">X in camera coordinates</param>
+    /// <param name="y">Y in camera coordinates</param>
+    /// <param name="z">Z in camera coordinates</param>
+    /// <param name="focalLengthX">Normalized focal length X in NDC space</param>
+    /// <param name="focalLengthY">Normalized focal length Y in NDC space</param>
+    /// <param name="principalX">Normalized principal point X in NDC space</param>
+    /// <param name="principalY">Normalized principal point Y in NDC space</param>
+    /// <param name="zScale">Ratio of Z values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 CameraToPoint(UnityEngine.Rect rectangle, float x, float y, float z,
+                                        float focalLengthX, float focalLengthY, float principalX, float principalY,
+                                        float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return CameraToLocalPoint(x, y, z, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, focalLengthX, focalLengthY, principalX, principalY,
+                                zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from camera coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="x">X in camera coordinates</param>
+    /// <param name="y">Y in camera coordinates</param>
+    /// <param name="z">Z in camera coordinates</param>
+    /// <param name="focalLength">Normalized focal lengths in NDC space</param>
+    /// <param name="principalPoint">Normalized principal point in NDC space</param>
+    /// <param name="zScale">Ratio of Z values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 CameraToPoint(UnityEngine.Rect rectangle, float x, float y, float z,
+                                        Vector2 focalLength, Vector2 principalPoint,
+                                        float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return CameraToLocalPoint(x, y, z, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, focalLength.x, focalLength.y, principalPoint.x, principalPoint.y,
+                                zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from camera coordinates to local coordinates in Unity.
+    ///   It is assumed that the principal point is (0, 0) in the local coordinate system and the focal length is (0, 0).
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="x">X in camera coordinates</param>
+    /// <param name="y">Y in camera coordinates</param>
+    /// <param name="z">Z in camera coordinates</param>
+    /// <param name="zScale">Ratio of Z values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 CameraToPoint(UnityEngine.Rect rectangle, float x, float y, float z,
+                                        float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      var principalPoint = rectangle.PointToNDC(new Vector2(0.0f, 0.0f), imageRotation, isMirrored);
+      return CameraToLocalPoint(x, y, z, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, Vector2.one, principalPoint, zScale, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get the coordinates represented by <paramref name="point3d" /> in local coordinate system.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
-    /// <param name="focalLength">Focal lengths in image coordinates</param>
-    /// <param name="principalPoint">Principal point in image coordinates</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="focalLengthX">Normalized focal length X in NDC space</param>
+    /// <param name="focalLengthY">Normalized focal length Y in NDC space</param>
+    /// <param name="principalX">Normalized principal point X in NDC space</param>
+    /// <param name="principalY">Normalized principal point Y in NDC space</param>
     /// <param name="zScale">Ratio of values in camera coordinates to local coordinates in Unity</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(this RectTransform rectTransform, Point3D point3d, Vector2 focalLength, Vector2 principalPoint, float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 GetPoint(this UnityEngine.Rect rectangle, Point3D point3d, float focalLengthX, float focalLengthY, float principalX, float principalY,
+                                   float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPosition(rectTransform, point3d.X, point3d.Y, point3d.Z, focalLength, principalPoint, zScale, imageRotation, isMirrored);
+      return CameraToPoint(rectangle, point3d.X, point3d.Y, point3d.Z, focalLengthX, focalLengthY, principalX, principalY, zScale, imageRotation, isMirrored);
     }
 
+    /// <summary>
+    ///   Get the coordinates represented by <paramref name="point3d" /> in local coordinate system.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="focalLength">Normalized focal lengths in NDC space</param>
+    /// <param name="principalPoint">Normalized principal point in NDC space</param>
+    /// <param name="zScale">Ratio of values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 GetPoint(this UnityEngine.Rect rectangle, Point3D point3d, Vector2 focalLength, Vector2 principalPoint,
+                                   float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return CameraToPoint(rectangle, point3d.X, point3d.Y, point3d.Z, focalLength, principalPoint, zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Get the coordinates represented by <paramref name="point3d" /> in local coordinate system.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="zScale">Ratio of values in camera coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 GetPoint(this UnityEngine.Rect rectangle, Point3D point3d,
+                                   float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return CameraToPoint(rectangle, point3d.X, point3d.Y, point3d.Z, zScale, imageRotation, isMirrored);
+    }
+
+    public static Vector2 PointToNDC(this UnityEngine.Rect rectangle, float x, float y, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      var normalizedX = 0.0f;
+      if (rectangle.xMax != rectangle.xMin)
+      {
+        normalizedX = IsXReversed(imageRotation, isMirrored) ?
+            (rectangle.xMax - x) / (rectangle.xMax - rectangle.xMin) :
+            (x - rectangle.xMin) / (rectangle.xMax - rectangle.xMin);
+      }
+
+      var normalizedY = 0.0f;
+      if (rectangle.yMax != rectangle.yMin)
+      {
+        normalizedX = IsXReversed(imageRotation, isMirrored) ?
+            (rectangle.yMax - y) / (rectangle.yMax - rectangle.yMin) :
+            (y - rectangle.yMin) / (rectangle.yMax - rectangle.yMin);
+      }
+
+      var ndcX = (2 * normalizedX) - 1.0f;
+      var ndcY = (2 * normalizedY) - 1.0f;
+
+      return IsInverted(imageRotation) ? new Vector2(ndcY, ndcX) : new Vector2(ndcX, ndcY);
+    }
+
+    public static Vector2 PointToNDC(this UnityEngine.Rect rectangle, Vector2 localPosition, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return rectangle.PointToNDC(localPosition.x, localPosition.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation180" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
+    ///   because the original Y axis will be exactly opposite the X axis in Unity coordinates if the image is rotated back.
+    /// </summary>
     public static bool IsXReversed(RotationAngle rotationAngle, bool isMirrored = false)
     {
       return isMirrored ?
@@ -63,6 +241,11 @@ namespace Mediapipe.Unity.CoordinateSystem
         rotationAngle == RotationAngle.Rotation180 || rotationAngle == RotationAngle.Rotation270;
     }
 
+    /// <summary>
+    ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation180" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
+    ///   because the original X axis will be exactly opposite the Y axis in Unity coordinates if the image is rotated back.
+    /// </summary>
     public static bool IsYReversed(RotationAngle rotationAngle, bool isMirrored = false)
     {
       return isMirrored ?
@@ -70,6 +253,9 @@ namespace Mediapipe.Unity.CoordinateSystem
         rotationAngle == RotationAngle.Rotation90 || rotationAngle == RotationAngle.Rotation180;
     }
 
+    /// <summary>
+    ///   Returns <c>true</c> if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> or <see cref="RotationAngle.Rotation270" />.
+    /// </summary>
     public static bool IsInverted(RotationAngle rotationAngle)
     {
       return rotationAngle == RotationAngle.Rotation90 || rotationAngle == RotationAngle.Rotation270;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/CameraCoordinate.cs
@@ -17,6 +17,13 @@ namespace Mediapipe.Unity.CoordinateSystem
   /// </remarks>
   public static class CameraCoordinate
   {
+    public static Vector3 CameraToRealWorld(float x, float y, float z, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      var isInverted = IsInverted(imageRotation);
+      var (rx, ry) = isInverted ? (y, x) : (x, y);
+      return new Vector3(IsXReversed(imageRotation, isMirrored) ? -rx : rx, IsYReversed(imageRotation, isMirrored) ? -ry : ry, -z);
+    }
+
     /// <summary>
     ///   Convert from camera coordinates to local coordinates in Unity.
     /// </summary>

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
@@ -31,7 +31,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
@@ -56,7 +56,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
@@ -71,12 +71,12 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">
-    ///   The position in the image coordinate system.<br/>
+    ///   The position in the image coordinate system.
     ///   If <c>position.z</c> is not zero, it's assumed to be the depth value in the local coordinate system.
     /// </param>
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
@@ -95,7 +95,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
@@ -112,7 +112,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
@@ -135,7 +135,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
     /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -160,7 +160,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
     /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -178,7 +178,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -200,7 +200,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
     /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -221,7 +221,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
     /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -238,7 +238,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -255,7 +255,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -272,7 +272,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
@@ -282,7 +282,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left.
     /// </summary>
     /// <remarks>
@@ -293,7 +293,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="yMin">Topmost Y value</param>
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xMin, int yMin, int width, int height,
                                                 int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -304,7 +307,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left.
     /// </summary>
     /// <remarks>
@@ -314,7 +317,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="xMin">Leftmost X value</param>
     /// <param name="yMin">Topmost Y value</param>
     /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xMin, int yMin, int width, int height,
                                                 Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -323,7 +329,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left.
     /// </summary>
     /// <remarks>
@@ -334,7 +340,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedYMin">Normalized topmost Y value</param>
     /// <param name="normalizedWidth">Normalized width</param>
     /// <param name="normalizedHeight">Normalized height</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageNormalizedToRectVertices(UnityEngine.Rect rectangle, float normalizedXMin, float normalizedYMin, float normalizedWidth, float normalizedHeight,
                                                           RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -345,7 +354,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
@@ -354,7 +363,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="rotation">Clockwise rotation angle in radians</param>
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xCenter, int yCenter, int width, int height, float rotation,
                                                 int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -378,7 +390,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
@@ -386,7 +398,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="yCenter">Y value of the rectangle's center coordinate</param>
     /// <param name="rotation">Clockwise rotation angle in radians</param>
     /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xCenter, int yCenter, int width, int height, float rotation,
                                                 Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -395,7 +410,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   Returns a <see cref="Vector3" /> array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
@@ -404,7 +419,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedWidth">Normalized width</param>
     /// <param name="normalizedHeight">Normalized height</param>
     /// <param name="rotation">Clockwise rotation angle in radians</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] ImageNormalizedToRectVertices(UnityEngine.Rect rectangle, float normalizedXCenter, float normalizedYCenter, float normalizedWidth, float normalizedHeight,
                                                           float rotation, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -447,7 +465,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Get the coordinates represented by <paramref name="relativeKeypoint" /> in the local coordinate system.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector2 GetPoint(this UnityEngine.Rect rectangle, mplt.RelativeKeypoint relativeKeypoint,
                                    RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -459,7 +480,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Get the coordinates represented by <paramref name="normalizedLandmark" /> in the local coordinate system.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3 GetPoint(this UnityEngine.Rect rectangle, NormalizedLandmark normalizedLandmark,
                                    RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -468,10 +492,13 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get the coordinates represented by <paramref name="point2d" /> in local coordinate system.
+    ///   Get the coordinates represented by <paramref name="point2d" /> in the local coordinate system.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3 GetPoint(this UnityEngine.Rect rectangle, NormalizedPoint2D point2d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
@@ -479,10 +506,13 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get the coordinates represented by <paramref name="anchor3d" /> in local coordinate system.
+    ///   Get the coordinates represented by <paramref name="anchor3d" /> in the local coordinate system.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector2 GetPoint(this UnityEngine.Rect rectangle, Anchor3d anchor3d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
@@ -490,13 +520,16 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.BoundingBox boundingBox, int imageWidth, int imageHeight,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -505,12 +538,15 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.BoundingBox boundingBox, Vector2Int imageSize,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -519,11 +555,14 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.RelativeBoundingBox boundingBox,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -532,13 +571,16 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageWidth">Image width in pixels</param>
     /// <param name="imageHeight">Image width in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, Rect rect, int imageWidth, int imageHeight,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -547,12 +589,15 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, Rect rect, Vector2Int imageSize,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -561,11 +606,14 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get a Vector3 array which represents <paramref name="normalizedRect" />'s vertex coordinates in local coordinate system.
+    ///   Get a Vector3 array which represents <paramref name="normalizedRect" />'s vertex coordinates in the local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
     /// <param name="rectangle">Rectangle to get a point inside</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, NormalizedRect normalizedRect,
                                             RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
@@ -573,6 +621,15 @@ namespace Mediapipe.Unity.CoordinateSystem
       return ImageNormalizedToRectVertices(rectangle, normalizedRect.XCenter, normalizedRect.YCenter, normalizedRect.Width, normalizedRect.Height, normalizedRect.Rotation, imageRotation, isMirrored);
     }
 
+    /// <summary>
+    ///   Get the image normalized point corresponding to <paramref name="localPosition" />.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
     public static Vector2 PointToImageNormalized(this UnityEngine.Rect rectangle, Vector2 localPosition, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       var normalizedX = IsXReversed(imageRotation, isMirrored) ?
@@ -586,7 +643,7 @@ namespace Mediapipe.Unity.CoordinateSystem
 
     /// <summary>
     ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
-    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>False</c>, this returns <c>True</c>
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
     ///   because the original Y axis will be exactly opposite the X axis in Unity coordinates if the image is rotated back.
     /// </summary>
     public static bool IsXReversed(RotationAngle rotationAngle, bool isMirrored = false)
@@ -598,7 +655,7 @@ namespace Mediapipe.Unity.CoordinateSystem
 
     /// <summary>
     ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
-    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>False</c>, this returns <c>True</c>
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
     ///   because the original X axis will be exactly opposite the Y axis in Unity coordinates if the image is rotated back.
     /// </summary>
     public static bool IsYReversed(RotationAngle rotationAngle, bool isMirrored = false)
@@ -608,6 +665,9 @@ namespace Mediapipe.Unity.CoordinateSystem
         rotationAngle == RotationAngle.Rotation0 || rotationAngle == RotationAngle.Rotation90;
     }
 
+    /// <summary>
+    ///   Returns <c>true</c> if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> or <see cref="RotationAngle.Rotation270" />.
+    /// </summary>
     public static bool IsInverted(RotationAngle rotationAngle)
     {
       return rotationAngle == RotationAngle.Rotation90 || rotationAngle == RotationAngle.Rotation270;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
@@ -18,28 +18,135 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
     /// <param name="x">Column value in the image coordinate system</param>
     /// <param name="y">Row value in the image coordinate system</param>
-    /// <param name="z">Depth value in local coordinate system</param>
-    /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(RectTransform rectTransform, int x, int y, int z, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    /// <param name="z">Depth value in the local coordinate system</param>
+    /// <param name="screenWidth">
+    ///   The target screen width. The returned value will be local to this screen.
+    /// </param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToLocalPoint(int x, int y, int z, float xMin, float xMax, float yMin, float yMax,
+                                            int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var rect = rectTransform.rect;
       var isInverted = IsInverted(imageRotation);
       var (rectX, rectY) = isInverted ? (y, x) : (x, y);
-      var localX = ((IsXReversed(imageRotation, isMirrored) ? imageSize.x - rectX : rectX) * rect.width / imageSize.x) - (rect.width / 2);
-      var localY = ((IsYReversed(imageRotation, isMirrored) ? imageSize.y - rectY : rectY) * rect.height / imageSize.y) - (rect.height / 2);
+      var (width, height) = (xMax - xMin, yMax - yMin);
+      var localX = ((IsXReversed(imageRotation, isMirrored) ? imageWidth - rectX : rectX) * width / imageWidth) + xMin;
+      var localY = ((IsYReversed(imageRotation, isMirrored) ? imageHeight - rectY : rectY) * height / imageHeight) + yMin;
       return new Vector3(localX, localY, z);
     }
 
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="x">Column value in the image coordinate system</param>
+    /// <param name="y">Row value in the image coordinate system</param>
+    /// <param name="z">Depth value in the local coordinate system</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToPoint(UnityEngine.Rect rect, int x, int y, int z,
+                                       int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToLocalPoint(x, y, z, rect.xMin, rect.xMax, rect.yMin, rect.yMax, imageWidth, imageHeight, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="position">
+    ///   The position in the image coordinate system.<br/>
+    ///   If <c>position.z</c> is not zero, it's assumed to be the depth value in the local coordinate system.
+    /// </param>
+    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToPoint(UnityEngine.Rect rect, Vector3Int position,
+                                       Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToPoint(rect, position.x, position.y, position.z, imageSize.x, imageSize.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="x">Column value in the image coordinate system</param>
+    /// <param name="y">Row value in the image coordinate system</param>
+    /// <param name="z">Depth value in the local coordinate system</param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToLocalPoint(int x, int y, float xMin, float xMax, float yMin, float yMax,
+                                            int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToLocalPoint(x, y, 0, xMin, xMax, yMin, yMax, imageWidth, imageHeight, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="x">Column value in the image coordinate system</param>
+    /// <param name="y">Row value in the image coordinate system</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToPoint(UnityEngine.Rect rect, int x, int y,
+                                       int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToPoint(rect, x, y, 0, imageWidth, imageHeight, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="position">The position in the image coordinate system</param>
+    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
+    public static Vector3 ImageToPoint(UnityEngine.Rect rect, Vector2Int position, Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToPoint(rect, position.x, position.y, imageSize.x, imageSize.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
     /// <param name="rectTransform">
     ///   <see cref="RectTransform" /> to be used for calculating local coordinates
     /// </param>
@@ -49,9 +156,28 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageToPoint instead")]
+    public static Vector3 GetLocalPosition(RectTransform rectTransform, int x, int y, int z, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToPoint(rectTransform.rect, x, y, z, (int)imageSize.x, (int)imageSize.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert from image coordinates to local coordinates in Unity.
+    /// </summary>
+    /// <param name="rectTransform">
+    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
+    /// </param>
+    /// <param name="x">Column value in the image coordinate system</param>
+    /// <param name="y">Row value in the image coordinate system</param>
+    /// <param name="z">Depth value in local coordinate system</param>
+    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageToPoint instead")]
     public static Vector3 GetLocalPosition(RectTransform rectTransform, int x, int y, int z, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPosition(rectTransform, x, y, z, new Vector2(rectTransform.rect.width, rectTransform.rect.height), imageRotation, isMirrored);
+      return ImageToPoint(rectTransform.rect, x, y, z, (int)rectTransform.rect.width, (int)rectTransform.rect.height, imageRotation, isMirrored);
     }
 
     /// <summary>
@@ -65,9 +191,138 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageToPoint instead")]
     public static Vector2 GetLocalPosition(RectTransform rectTransform, int x, int y, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       return GetLocalPosition(rectTransform, x, y, 0, imageSize, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
+    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
+    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToLocalPoint(float normalizedX, float normalizedY, float normalizedZ, float xMin, float xMax, float yMin, float yMax,
+                                                      float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      var isInverted = IsInverted(imageRotation);
+      var (nx, ny) = isInverted ? (normalizedY, normalizedX) : (normalizedX, normalizedY);
+      var x = IsXReversed(imageRotation, isMirrored) ? Mathf.LerpUnclamped(xMax, xMin, nx) : Mathf.LerpUnclamped(xMin, xMax, nx);
+      var y = IsYReversed(imageRotation, isMirrored) ? Mathf.LerpUnclamped(yMax, yMin, ny) : Mathf.LerpUnclamped(yMin, yMax, ny);
+      var z = zScale * normalizedZ;
+      return new Vector3(x, y, z);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
+    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
+    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, float normalizedX, float normalizedY, float normalizedZ,
+                                                 float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rect.xMin, rect.xMax, rect.yMin, rect.yMax, zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="position">The position in the image coordinate system</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, Vector3 position,
+                                                 float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageNormalizedToPoint(rect, position.x, position.y, position.z, zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
+    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
+    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
+    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
+    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToLocalPoint(float normalizedX, float normalizedY, float normalizedZ, float xMin, float xMax, float yMin, float yMax,
+                                                      RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      // Z usually uses roughly the same scale as X
+      var zScale = IsInverted(imageRotation) ? (yMax - yMin) : (xMax - xMin);
+      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, xMin, xMax, yMin, yMax, zScale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
+    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
+    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, float normalizedX, float normalizedY, float normalizedZ,
+                                                 RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rect.xMin, rect.xMax, rect.yMin, rect.yMax, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
+    /// </summary>
+    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="position">The position in the image coordinate system</param>
+    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, Vector3 position, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageNormalizedToPoint(rect, position.x, position.y, position.z, imageRotation, isMirrored);
     }
 
     /// <summary>
@@ -83,6 +338,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageNormalizedToPoint instead")]
     public static Vector3 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, float normalizedZ, float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       var rect = rectTransform.rect;
@@ -106,6 +362,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageNormalizedToPoint instead")]
     public static Vector3 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, float normalizedZ, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       // Z usually uses roughly the same scale as X
@@ -124,6 +381,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    [System.Obsolete("Use ImageNormalizedToPoint instead")]
     public static Vector2 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       return GetLocalPositionNormalized(rectTransform, normalizedX, normalizedY, 0.0f, imageRotation, isMirrored);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/ImageCoordinate.cs
@@ -49,7 +49,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="x">Column value in the image coordinate system</param>
     /// <param name="y">Row value in the image coordinate system</param>
     /// <param name="z">Depth value in the local coordinate system</param>
@@ -60,16 +60,16 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
-    public static Vector3 ImageToPoint(UnityEngine.Rect rect, int x, int y, int z,
+    public static Vector3 ImageToPoint(UnityEngine.Rect rectangle, int x, int y, int z,
                                        int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageToLocalPoint(x, y, z, rect.xMin, rect.xMax, rect.yMin, rect.yMax, imageWidth, imageHeight, imageRotation, isMirrored);
+      return ImageToLocalPoint(x, y, z, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, imageWidth, imageHeight, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">
     ///   The position in the image coordinate system.<br/>
     ///   If <c>position.z</c> is not zero, it's assumed to be the depth value in the local coordinate system.
@@ -80,39 +80,16 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
-    public static Vector3 ImageToPoint(UnityEngine.Rect rect, Vector3Int position,
+    public static Vector3 ImageToPoint(UnityEngine.Rect rectangle, Vector3Int position,
                                        Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageToPoint(rect, position.x, position.y, position.z, imageSize.x, imageSize.y, imageRotation, isMirrored);
+      return ImageToPoint(rectangle, position.x, position.y, position.z, imageSize.x, imageSize.y, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="x">Column value in the image coordinate system</param>
-    /// <param name="y">Row value in the image coordinate system</param>
-    /// <param name="z">Depth value in the local coordinate system</param>
-    /// <param name="xMin">The minimum X coordinate of the target rectangle</param>
-    /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
-    /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
-    /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
-    /// <param name="imageWidth">Image width in pixels</param>
-    /// <param name="imageHeight">Image width in pixels</param>
-    /// <param name="imageRotation">
-    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
-    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
-    /// </param>
-    /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
-    public static Vector3 ImageToLocalPoint(int x, int y, float xMin, float xMax, float yMin, float yMax,
-                                            int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      return ImageToLocalPoint(x, y, 0, xMin, xMax, yMin, yMax, imageWidth, imageHeight, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Convert from image coordinates to local coordinates in Unity.
-    /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="x">Column value in the image coordinate system</param>
     /// <param name="y">Row value in the image coordinate system</param>
     /// <param name="imageWidth">Image width in pixels</param>
@@ -122,16 +99,16 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
-    public static Vector3 ImageToPoint(UnityEngine.Rect rect, int x, int y,
+    public static Vector3 ImageToPoint(UnityEngine.Rect rectangle, int x, int y,
                                        int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageToPoint(rect, x, y, 0, imageWidth, imageHeight, imageRotation, isMirrored);
+      return ImageToLocalPoint(x, y, 0, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, imageWidth, imageHeight, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert from image coordinates to local coordinates in Unity.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">
@@ -139,62 +116,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the image coordinates is mirrored</param>
-    public static Vector3 ImageToPoint(UnityEngine.Rect rect, Vector2Int position, Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 ImageToPoint(UnityEngine.Rect rectangle, Vector2Int position, Vector2Int imageSize,
+                                       RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageToPoint(rect, position.x, position.y, imageSize.x, imageSize.y, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Convert from image coordinates to local coordinates in Unity.
-    /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
-    /// <param name="x">Column value in the image coordinate system</param>
-    /// <param name="y">Row value in the image coordinate system</param>
-    /// <param name="z">Depth value in local coordinate system</param>
-    /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageToPoint instead")]
-    public static Vector3 GetLocalPosition(RectTransform rectTransform, int x, int y, int z, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      return ImageToPoint(rectTransform.rect, x, y, z, (int)imageSize.x, (int)imageSize.y, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Convert from image coordinates to local coordinates in Unity.
-    /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
-    /// <param name="x">Column value in the image coordinate system</param>
-    /// <param name="y">Row value in the image coordinate system</param>
-    /// <param name="z">Depth value in local coordinate system</param>
-    /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageToPoint instead")]
-    public static Vector3 GetLocalPosition(RectTransform rectTransform, int x, int y, int z, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      return ImageToPoint(rectTransform.rect, x, y, z, (int)rectTransform.rect.width, (int)rectTransform.rect.height, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Convert from image coordinates to local coordinates in Unity.
-    /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
-    /// <param name="x">Column value in the image coordinate system</param>
-    /// <param name="y">Row value in the image coordinate system</param>
-    /// <param name="imageSize">Image size in pixels</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageToPoint instead")]
-    public static Vector2 GetLocalPosition(RectTransform rectTransform, int x, int y, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      return GetLocalPosition(rectTransform, x, y, 0, imageSize, imageRotation, isMirrored);
+      return ImageToPoint(rectangle, position.x, position.y, imageSize.x, imageSize.y, imageRotation, isMirrored);
     }
 
     /// <summary>
@@ -229,7 +154,7 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
     ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
     /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
@@ -239,17 +164,17 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, float normalizedX, float normalizedY, float normalizedZ,
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, float normalizedX, float normalizedY, float normalizedZ,
                                                  float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rect.xMin, rect.xMax, rect.yMin, rect.yMax, zScale, imageRotation, isMirrored);
+      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, zScale, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
     ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">The position in the image coordinate system</param>
     /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
@@ -257,10 +182,10 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, Vector3 position,
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, Vector3 position,
                                                  float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageNormalizedToPoint(rect, position.x, position.y, position.z, zScale, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, position.x, position.y, position.z, zScale, imageRotation, isMirrored);
     }
 
     /// <summary>
@@ -274,7 +199,6 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="xMax">The maximum X coordinate of the target rectangle</param>
     /// <param name="yMin">The minimum X coordinate of the target rectangle</param>
     /// <param name="yMax">The maximum X coordinate of the target rectangle</param>
-    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
     ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
@@ -292,99 +216,69 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
     ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
     /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
-    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
     ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, float normalizedX, float normalizedY, float normalizedZ,
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, float normalizedX, float normalizedY, float normalizedZ,
                                                  RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rect.xMin, rect.xMax, rect.yMin, rect.yMax, imageRotation, isMirrored);
+      return ImageNormalizedToLocalPoint(normalizedX, normalizedY, normalizedZ, rectangle.xMin, rectangle.xMax, rectangle.yMin, rectangle.yMax, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
     ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rect">Rectangle to get a point inside</param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="position">The position in the image coordinate system</param>
-    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
     /// <param name="imageRotation">
     ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
     ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rect, Vector3 position, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, Vector3 position, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return ImageNormalizedToPoint(rect, position.x, position.y, position.z, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, position.x, position.y, position.z, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
-    ///   If the normalized values are out of [0, 1], the return value will be outside <paramref name="rectTransform" />'s rect.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
     /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
-    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
-    /// <param name="zScale">Ratio of Z value in image coordinates to local coordinates in Unity</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageNormalizedToPoint instead")]
-    public static Vector3 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, float normalizedZ, float zScale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, float normalizedX, float normalizedY,
+                                                 RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var rect = rectTransform.rect;
-      var isInverted = IsInverted(imageRotation);
-      var (nx, ny) = isInverted ? (normalizedY, normalizedX) : (normalizedX, normalizedY);
-      var x = IsXReversed(imageRotation, isMirrored) ? Mathf.LerpUnclamped(rect.xMax, rect.xMin, nx) : Mathf.LerpUnclamped(rect.xMin, rect.xMax, nx);
-      var y = IsYReversed(imageRotation, isMirrored) ? Mathf.LerpUnclamped(rect.yMax, rect.yMin, ny) : Mathf.LerpUnclamped(rect.yMin, rect.yMax, ny);
-      var z = zScale * normalizedZ;
-      return new Vector3(x, y, z);
+      return ImageNormalizedToPoint(rectangle, normalizedX, normalizedY, 0, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
-    ///   If the normalized values are out of [0, 1], the return value will be outside <paramref name="rectTransform" />'s rect.
+    ///   If the normalized values are out of [0, 1], the return value will be off the target screen.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="position">The position in the image coordinate system</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.<br/>
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
-    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
-    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
-    /// <param name="normalizedZ">Normalized z value in the image coordinate system</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageNormalizedToPoint instead")]
-    public static Vector3 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, float normalizedZ, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 ImageNormalizedToPoint(UnityEngine.Rect rectangle, Vector2 position, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      // Z usually uses roughly the same scale as X
-      var zScale = IsInverted(imageRotation) ? rectTransform.rect.height : rectTransform.rect.width;
-      return GetLocalPositionNormalized(rectTransform, normalizedX, normalizedY, normalizedZ, zScale, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Convert normalized values in the image coordinate system to local coordinate values in Unity.
-    ///   If the normalized values are out of [0, 1], the return value will be outside <paramref name="rectTransform" />'s rect.
-    /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
-    /// <param name="normalizedX">Normalized x value in the image coordinate system</param>
-    /// <param name="normalizedY">Normalized y value in the image coordinate system</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    [System.Obsolete("Use ImageNormalizedToPoint instead")]
-    public static Vector2 GetLocalPositionNormalized(RectTransform rectTransform, float normalizedX, float normalizedY, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      return GetLocalPositionNormalized(rectTransform, normalizedX, normalizedY, 0.0f, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, position.x, position.y, imageRotation, isMirrored);
     }
 
     /// <summary>
@@ -394,18 +288,18 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <remarks>
     ///   Z values are always zero.
     /// </remarks>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="xMin">Leftmost X value</param>
     /// <param name="yMin">Topmost Y value</param>
-    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVertices(RectTransform rectTransform, int xMin, int yMin, int width, int height, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xMin, int yMin, int width, int height,
+                                                int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var p = GetLocalPosition(rectTransform, xMin, yMin + height, imageSize, imageRotation, isMirrored);
-      var q = GetLocalPosition(rectTransform, xMin + width, yMin, imageSize, imageRotation, isMirrored);
+      var p = ImageToPoint(rectangle, xMin, yMin + height, imageWidth, imageHeight, imageRotation, isMirrored);
+      var q = ImageToPoint(rectangle, xMin + width, yMin, imageWidth, imageHeight, imageRotation, isMirrored);
       return GetRectVertices(p, q);
     }
 
@@ -413,19 +307,40 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Returns a Vector3 array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <remarks>
+    ///   Z values are always zero.
+    /// </remarks>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="xMin">Leftmost X value</param>
+    /// <param name="yMin">Topmost Y value</param>
+    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xMin, int yMin, int width, int height,
+                                                Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToRectVertices(rectangle, xMin, yMin, width, height, imageSize.x, imageSize.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   They are in clockwise order, starting from the coordinate that was in the bottom-left.
+    /// </summary>
+    /// <remarks>
+    ///   Z values are always zero.
+    /// </remarks>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="normalizedXMin">Normalized leftmost X value</param>
     /// <param name="normalizedYMin">Normalized topmost Y value</param>
     /// <param name="normalizedWidth">Normalized width</param>
     /// <param name="normalizedHeight">Normalized height</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVerticesNormalized(RectTransform rectTransform, float normalizedXMin, float normalizedYMin, float normalizedWidth, float normalizedHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] ImageNormalizedToRectVertices(UnityEngine.Rect rectangle, float normalizedXMin, float normalizedYMin, float normalizedWidth, float normalizedHeight,
+                                                          RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var p = GetLocalPositionNormalized(rectTransform, normalizedXMin, normalizedYMin + normalizedHeight, imageRotation, isMirrored);
-      var q = GetLocalPositionNormalized(rectTransform, normalizedXMin + normalizedWidth, normalizedYMin, imageRotation, isMirrored);
+      var p = ImageNormalizedToPoint(rectangle, normalizedXMin, normalizedYMin + normalizedHeight, imageRotation, isMirrored);
+      var q = ImageNormalizedToPoint(rectangle, normalizedXMin + normalizedWidth, normalizedYMin, imageRotation, isMirrored);
       return GetRectVertices(p, q);
     }
 
@@ -433,21 +348,21 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Returns a Vector3 array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="xCenter">X value of the rectangle's center coordinate</param>
     /// <param name="yCenter">Y value of the rectangle's center coordinate</param>
     /// <param name="rotation">Clockwise rotation angle in radians</param>
-    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRotatedRectVertices(RectTransform rectTransform, int xCenter, int yCenter, int width, int height, float rotation, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xCenter, int yCenter, int width, int height, float rotation,
+                                                int imageWidth, int imageHeight, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       var isInverted = IsInverted(imageRotation);
       var (rectWidth, rectHeight) = IsInverted(imageRotation) ? (height, width) : (width, height);
 
-      Vector3 center = GetLocalPosition(rectTransform, xCenter, yCenter, imageSize, imageRotation, isMirrored);
+      var center = ImageToPoint(rectangle, xCenter, yCenter, imageWidth, imageHeight, imageRotation, isMirrored);
       var isRotationReversed = isInverted ^ IsXReversed(imageRotation, isMirrored) ^ IsYReversed(imageRotation, isMirrored);
       var quaternion = Quaternion.Euler(0, 0, (isRotationReversed ? -1 : 1) * Mathf.Rad2Deg * rotation);
 
@@ -466,9 +381,24 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Returns a Vector3 array which represents a rectangle's vertices.
     ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="xCenter">X value of the rectangle's center coordinate</param>
+    /// <param name="yCenter">Y value of the rectangle's center coordinate</param>
+    /// <param name="rotation">Clockwise rotation angle in radians</param>
+    /// <param name="imageSize">Image size in pixels</param>
+    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3[] ImageToRectVertices(UnityEngine.Rect rectangle, int xCenter, int yCenter, int width, int height, float rotation,
+                                                Vector2Int imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToRectVertices(rectangle, xCenter, yCenter, width, height, rotation, imageSize.x, imageSize.y, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Returns a Vector3 array which represents a rectangle's vertices.
+    ///   They are in clockwise order, starting from the coordinate that was in the bottom-left before the rotation.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="normalizedXCenter">X value of the rectangle's center coordinate</param>
     /// <param name="normalizedYCenter">Y value of the rectangle's center coordinate</param>
     /// <param name="normalizedWidth">Normalized width</param>
@@ -476,14 +406,14 @@ namespace Mediapipe.Unity.CoordinateSystem
     /// <param name="rotation">Clockwise rotation angle in radians</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRotatedRectVerticesNormalized(RectTransform rectTransform, float normalizedXCenter, float normalizedYCenter, float normalizedWidth, float normalizedHeight, float rotation, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] ImageNormalizedToRectVertices(UnityEngine.Rect rectangle, float normalizedXCenter, float normalizedYCenter, float normalizedWidth, float normalizedHeight,
+                                                          float rotation, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var rect = rectTransform.rect;
       var isInverted = IsInverted(imageRotation);
-      var width = rect.width * (isInverted ? normalizedHeight : normalizedWidth);
-      var height = rect.height * (isInverted ? normalizedWidth : normalizedHeight);
+      var width = rectangle.width * (isInverted ? normalizedHeight : normalizedWidth);
+      var height = rectangle.height * (isInverted ? normalizedWidth : normalizedHeight);
 
-      Vector3 center = GetLocalPositionNormalized(rectTransform, normalizedXCenter, normalizedYCenter, imageRotation, isMirrored);
+      var center = ImageNormalizedToPoint(rectangle, normalizedXCenter, normalizedYCenter, imageRotation, isMirrored);
       var isRotationReversed = isInverted ^ IsXReversed(imageRotation, isMirrored) ^ IsYReversed(imageRotation, isMirrored);
       var quaternion = Quaternion.Euler(0, 0, (isRotationReversed ? -1 : 1) * Mathf.Rad2Deg * rotation);
 
@@ -514,155 +444,143 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get the coordinates represented by <paramref name="relativeKeypoint" /> in local coordinate system.
+    ///   Get the coordinates represented by <paramref name="relativeKeypoint" /> in the local coordinate system.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector2 GetLocalPosition(this RectTransform rectTransform, mplt.RelativeKeypoint relativeKeypoint, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector2 GetPoint(this UnityEngine.Rect rectangle, mplt.RelativeKeypoint relativeKeypoint,
+                                   RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPositionNormalized(rectTransform, relativeKeypoint.X, relativeKeypoint.Y, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, relativeKeypoint.X, relativeKeypoint.Y, imageRotation, isMirrored);
     }
 
     /// <summary>
-    ///   Get the coordinates represented by <paramref name="normalizedLandmark" /> in local coordinate system.
+    ///   Get the coordinates represented by <paramref name="normalizedLandmark" /> in the local coordinate system.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(this RectTransform rectTransform, NormalizedLandmark normalizedLandmark, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 GetPoint(this UnityEngine.Rect rectangle, NormalizedLandmark normalizedLandmark,
+                                   RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPositionNormalized(rectTransform, normalizedLandmark.X, normalizedLandmark.Y, normalizedLandmark.Z, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, normalizedLandmark.X, normalizedLandmark.Y, normalizedLandmark.Z, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get the coordinates represented by <paramref name="point2d" /> in local coordinate system.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(this RectTransform rectTransform, NormalizedPoint2D point2d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 GetPoint(this UnityEngine.Rect rectangle, NormalizedPoint2D point2d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPositionNormalized(rectTransform, point2d.X, point2d.Y, imageRotation, isMirrored);
+      return ImageNormalizedToPoint(rectangle, point2d.X, point2d.Y, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get the coordinates represented by <paramref name="anchor3d" /> in local coordinate system.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector2 GetLocalPosition(this RectTransform rectTransform, Anchor3d anchor3d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector2 GetPoint(this UnityEngine.Rect rectangle, Anchor3d anchor3d, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPositionNormalized(rectTransform, anchor3d.x, anchor3d.y, imageRotation, isMirrored);
-    }
-
-    /// <summary>
-    ///   Get the coordinates represented by <paramref name="anchor3d" /> in local coordinate system.
-    ///   This method calculates the coordinates of the anchor so that it is projected to the correct position on the plane when viewed from the <paramref name="cameraPosition" />.
-    /// </summary>
-    /// <remarks>
-    ///   Assume that the camera is oriented perpendicular to the plane.
-    /// </remarks>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> that is attached to the target plane
-    /// </param>
-    /// <param name="cameraPosition">The position of the camera represented in local coordinates of the plane</param>
-    /// <param name="defaultDepth">
-    ///   Depth value when the anchor's Z is 1.0.
-    ///   Depth here refers to the distance from the camera on the Z axis.
-    /// </param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
-    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(this RectTransform rectTransform, Anchor3d anchor3d, Vector3 cameraPosition, float defaultDepth, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
-    {
-      if (Mathf.Approximately(cameraPosition.z, 0.0f))
-      {
-        throw new System.ArgumentException("Z value of the camera position must not be zero");
-      }
-
-      var cameraDepth = Mathf.Abs(cameraPosition.z);
-      var anchorPoint2d = rectTransform.GetLocalPosition(anchor3d, imageRotation, isMirrored);
-      var anchorDepth = anchor3d.z * defaultDepth;
-
-      // Maybe it should be defined as a CameraCoordinate method
-      var x = ((anchorPoint2d.x - cameraPosition.x) * anchorDepth / cameraDepth) + cameraPosition.x;
-      var y = ((anchorPoint2d.y - cameraPosition.y) * anchorDepth / cameraDepth) + cameraPosition.y;
-      var z = cameraPosition.z > 0 ? cameraPosition.z - anchorDepth : cameraPosition.z + anchorDepth;
-      return new Vector3(x, y, z);
+      return ImageNormalizedToPoint(rectangle, anchor3d.x, anchor3d.y, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.BoundingBox boundingBox, int imageWidth, int imageHeight,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToRectVertices(rectangle, boundingBox.Xmin, boundingBox.Ymin, boundingBox.Width, boundingBox.Height, imageWidth, imageHeight, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
+    ///   They are ordered clockwise from bottom-left point.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVertices(this RectTransform rectTransform, mplt.BoundingBox boundingBox, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.BoundingBox boundingBox, Vector2Int imageSize,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetRectVertices(rectTransform, boundingBox.Xmin, boundingBox.Ymin, boundingBox.Width, boundingBox.Height, imageSize, imageRotation, isMirrored);
+      return ImageToRectVertices(rectangle, boundingBox.Xmin, boundingBox.Ymin, boundingBox.Width, boundingBox.Height, imageSize, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get a Vector3 array which represents <paramref name="boundingBox" />'s vertex coordinates in local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVertices(this RectTransform rectTransform, mplt.RelativeBoundingBox boundingBox, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, mplt.RelativeBoundingBox boundingBox,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetRectVerticesNormalized(rectTransform, boundingBox.Xmin, boundingBox.Ymin, boundingBox.Width, boundingBox.Height, imageRotation, isMirrored);
+      return ImageNormalizedToRectVertices(rectangle, boundingBox.Xmin, boundingBox.Ymin, boundingBox.Width, boundingBox.Height, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
+    /// <param name="imageWidth">Image width in pixels</param>
+    /// <param name="imageHeight">Image width in pixels</param>
+    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, Rect rect, int imageWidth, int imageHeight,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return ImageToRectVertices(rectangle, rect.XCenter, rect.YCenter, rect.Width, rect.Height, rect.Rotation, imageWidth, imageHeight, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   Get a Vector3 array which represents <paramref name="rect" />'s vertex coordinates in local coordinate system.
+    ///   They are ordered clockwise from bottom-left point.
+    /// </summary>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageSize">Image size in pixels</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVertices(this RectTransform rectTransform, Rect rect, Vector2 imageSize, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, Rect rect, Vector2Int imageSize,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetRotatedRectVertices(rectTransform, rect.XCenter, rect.YCenter, rect.Width, rect.Height, rect.Rotation, imageSize, imageRotation, isMirrored);
+      return ImageToRectVertices(rectangle, rect.XCenter, rect.YCenter, rect.Width, rect.Height, rect.Rotation, imageSize, imageRotation, isMirrored);
     }
 
     /// <summary>
     ///   Get a Vector3 array which represents <paramref name="normalizedRect" />'s vertex coordinates in local coordinate system.
     ///   They are ordered clockwise from bottom-left point.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
+    /// <param name="rectangle">Rectangle to get a point inside</param>
     /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3[] GetRectVertices(this RectTransform rectTransform, NormalizedRect normalizedRect, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3[] GetRectVertices(this UnityEngine.Rect rectangle, NormalizedRect normalizedRect,
+                                            RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetRotatedRectVerticesNormalized(rectTransform, normalizedRect.XCenter, normalizedRect.YCenter, normalizedRect.Width, normalizedRect.Height, normalizedRect.Rotation, imageRotation, isMirrored);
+      return ImageNormalizedToRectVertices(rectangle, normalizedRect.XCenter, normalizedRect.YCenter, normalizedRect.Width, normalizedRect.Height, normalizedRect.Rotation, imageRotation, isMirrored);
     }
 
-    public static Vector2 GetNormalizedPosition(this RectTransform rectTransform, Vector2 localPosition, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector2 PointToImageNormalized(this UnityEngine.Rect rectangle, Vector2 localPosition, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      var rect = rectTransform.rect;
-      var normalizedX = IsXReversed(imageRotation, isMirrored) ? Mathf.InverseLerp(rect.width / 2, -rect.width / 2, localPosition.x) : Mathf.InverseLerp(-rect.width / 2, rect.width / 2, localPosition.x);
-      var normalizedY = IsYReversed(imageRotation, isMirrored) ? Mathf.InverseLerp(rect.height / 2, -rect.height / 2, localPosition.y) : Mathf.InverseLerp(-rect.height / 2, rect.height / 2, localPosition.y);
+      var normalizedX = IsXReversed(imageRotation, isMirrored) ?
+          Mathf.InverseLerp(rectangle.width / 2, -rectangle.width / 2, localPosition.x) :
+          Mathf.InverseLerp(-rectangle.width / 2, rectangle.width / 2, localPosition.x);
+      var normalizedY = IsYReversed(imageRotation, isMirrored) ?
+          Mathf.InverseLerp(rectangle.height / 2, -rectangle.height / 2, localPosition.y) :
+          Mathf.InverseLerp(-rectangle.height / 2, rectangle.height / 2, localPosition.y);
       return IsInverted(imageRotation) ? new Vector2(normalizedY, normalizedX) : new Vector2(normalizedX, normalizedY);
     }
 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/RealWorldCoordinate.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/CoordinateSystem/RealWorldCoordinate.cs
@@ -18,16 +18,17 @@ namespace Mediapipe.Unity.CoordinateSystem
     ///   Convert from real world coordinates to Unity local coordinates.
     ///   Assume that the origin is common to the two coordinate systems.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
-    /// </param>
     /// <param name="x">X in real world coordinates</param>
     /// <param name="y">Y in real world coordinates</param>
     /// <param name="z">Z in real world coordinates</param>
     /// <param name="scale">Ratio of real world coordinate values to local coordinate values</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(float x, float y, float z, Vector3 scale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 RealWorldToLocalPoint(float x, float y, float z, Vector3 scale,
+                                                RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
       var (rx, ry) = IsInverted(imageRotation) ? (y, x) : (x, y);
       var realX = IsXReversed(imageRotation, isMirrored) ? -rx : rx;
@@ -36,19 +37,45 @@ namespace Mediapipe.Unity.CoordinateSystem
     }
 
     /// <summary>
-    ///   Get the coordinates represented by <paramref name="landmark" /> in local coordinate system.
+    ///   Convert from real world coordinates to Unity local coordinates.
+    ///   Assume that the origin is common to the two coordinate systems.
     /// </summary>
-    /// <param name="rectTransform">
-    ///   <see cref="RectTransform" /> to be used for calculating local coordinates
+    /// <param name="x">X in real world coordinates</param>
+    /// <param name="y">Y in real world coordinates</param>
+    /// <param name="z">Z in real world coordinates</param>
+    /// <param name="scaleX">Ratio of real world coordinate X to local coordinate X</param>
+    /// <param name="scaleY">Ratio of real world coordinate Y to local coordinate Y</param>
+    /// <param name="scaleZ">Ratio of real world coordinate Z to local coordinate Z</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
     /// </param>
-    /// <param name="scale">Ratio of real world coordinate values to local coordinate values</param>
-    /// <param name="imageRotation">Counterclockwise rotation angle of the input image</param>
     /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
-    public static Vector3 GetLocalPosition(this RectTransform _, Landmark landmark, Vector3 scale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    public static Vector3 RealWorldToLocalPoint(float x, float y, float z, float scaleX = 1, float scaleY = 1, float scaleZ = 1,
+                                                RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
     {
-      return GetLocalPosition(landmark.X, landmark.Y, landmark.Z, scale, imageRotation, isMirrored);
+      return RealWorldToLocalPoint(x, y, z, new Vector3(scaleX, scaleY, scaleZ), imageRotation, isMirrored);
     }
 
+    /// <summary>
+    ///   Get the coordinates represented by <paramref name="landmark" /> in the local coordinate system.
+    /// </summary>
+    /// <param name="scale">Ratio of real world coordinate values to local coordinate values</param>
+    /// <param name="imageRotation">
+    ///   Counterclockwise rotation angle of the input image in the image coordinate system.
+    ///   In the local coordinate system, this value will often represent a clockwise rotation angle.
+    /// </param>
+    /// <param name="isMirrored">Set to true if the original coordinates is mirrored</param>
+    public static Vector3 GetPoint(this UnityEngine.Rect _, Landmark landmark, Vector3 scale, RotationAngle imageRotation = RotationAngle.Rotation0, bool isMirrored = false)
+    {
+      return RealWorldToLocalPoint(landmark.X, landmark.Y, landmark.Z, scale, imageRotation, isMirrored);
+    }
+
+    /// <summary>
+    ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
+    ///   because the original Y axis will be exactly opposite the X axis in Unity coordinates if the image is rotated back.
+    /// </summary>
     public static bool IsXReversed(RotationAngle rotationAngle, bool isMirrored = false)
     {
       return isMirrored ?
@@ -56,6 +83,11 @@ namespace Mediapipe.Unity.CoordinateSystem
         rotationAngle == RotationAngle.Rotation90 || rotationAngle == RotationAngle.Rotation180;
     }
 
+    /// <summary>
+    ///   When the image is rotated back, returns whether the axis parallel to the X axis of the Unity coordinates is pointing in the same direction as the X axis of the Unity coordinates.
+    ///   For example, if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> and <paramRef name="isMirrored" /> is <c>false</c>, this returns <c>true</c>
+    ///   because the original X axis will be exactly opposite the Y axis in Unity coordinates if the image is rotated back.
+    /// </summary>
     public static bool IsYReversed(RotationAngle rotationAngle, bool isMirrored = false)
     {
       return isMirrored ?
@@ -63,6 +95,9 @@ namespace Mediapipe.Unity.CoordinateSystem
         rotationAngle == RotationAngle.Rotation0 || rotationAngle == RotationAngle.Rotation90;
     }
 
+    /// <summary>
+    ///   Returns <c>true</c> if <paramref name="rotationAngle" /> is <see cref="RotationAngle.Rotation90" /> or <see cref="RotationAngle.Rotation270" />.
+    /// </summary>
     public static bool IsInverted(RotationAngle rotationAngle)
     {
       return rotationAngle == RotationAngle.Rotation90 || rotationAngle == RotationAngle.Rotation270;

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
@@ -13,7 +13,7 @@ namespace Tests
 {
   public class ImageCoordinateTest
   {
-    #region GetLocalPosition
+    #region ImageToLocalPoint
     [TestCase(640, 480, -160, 0, 10, RotationAngle.Rotation0, false, -480, 240, 10)]
     [TestCase(640, 480, 0, -160, 10, RotationAngle.Rotation0, false, -320, 400, 10)]
     [TestCase(640, 480, 800, 0, 10, RotationAngle.Rotation0, false, 480, 240, 10)]
@@ -78,14 +78,12 @@ namespace Tests
     [TestCase(640, 480, 0, 800, 10, RotationAngle.Rotation270, true, 480, 240, 10)]
     [TestCase(640, 480, 640, 640, 10, RotationAngle.Rotation270, true, 320, -400, 10)]
     [TestCase(640, 480, 480, 800, 10, RotationAngle.Rotation270, true, 480, -240, 10)]
-    public void GetLocalPosition_ShouldReturnLocalPosition_When_ImageSizeIsNotSpecified(int width, int height, int x, int y, int z, RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
+    public void ImageToPoint_ShouldReturnLocalPoint_When_ImageSizeIsSameAsScreenSize(int width, int height, int x, int y, int z, RotationAngle imageRotation, bool isMirrored,
+                                                                                     float expectedX, float expectedY, float expectedZ)
     {
-      WithRectTransform((rectTransform) =>
-      {
-        rectTransform.sizeDelta = new Vector2(width, height);
-        var result = ImageCoordinate.GetLocalPosition(rectTransform, x, y, z, imageRotation, isMirrored);
-        Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
-      });
+      var rect = BuildRect(-width / 2, width / 2, -height / 2, height / 2);
+      var result = ImageCoordinate.ImageToPoint(rect, x, y, z, width, height, imageRotation, isMirrored);
+      Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
     }
 
     [TestCase(640, 480, 720, 540, -160, 0, 0, RotationAngle.Rotation0, false, -540, 270, 0)]
@@ -120,14 +118,92 @@ namespace Tests
     [TestCase(640, 480, 320, 240, 0, 800, 0, RotationAngle.Rotation270, false, 240, -120, 0)]
     [TestCase(640, 480, 320, 240, 640, 640, 0, RotationAngle.Rotation270, false, 160, 200, 0)]
     [TestCase(640, 480, 320, 240, 480, 800, 0, RotationAngle.Rotation270, false, 240, 120, 0)]
-    public void GetLocalPosition_ShouldReturnLocalPosition_When_ImageSizeIsSpecified(int imageWidth, int imageHeight, int width, int height, int x, int y, int z, RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
+    public void ImageToPoint_ShouldReturnLocalPoint_When_ImageSizeIsNotSameAsScreenSize(int imageWidth, int imageHeight, int width, int height, int x, int y, int z,
+                                                                                        RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
     {
-      WithRectTransform((rectTransform) =>
-      {
-        rectTransform.sizeDelta = new Vector2(width, height);
-        var result = ImageCoordinate.GetLocalPosition(rectTransform, x, y, z, new Vector2(imageWidth, imageHeight), imageRotation, isMirrored);
-        Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
-      });
+      var rect = BuildRect(-width / 2, width / 2, -height / 2, height / 2);
+      var result = ImageCoordinate.ImageToPoint(rect, x, y, z, imageWidth, imageHeight, imageRotation, isMirrored);
+      Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
+    }
+
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation0, false, 0, 480)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation0, true, 640, 480)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation90, false, 640, 480)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation90, true, 640, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation180, false, 640, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation180, true, 0, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation270, false, 0, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation270, true, 0, 480)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation0, false, -320, 480)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation0, true, 320, 480)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation90, false, 320, 480)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation90, true, 320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation180, false, 320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation180, true, -320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation270, false, -320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation270, true, -320, 480)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation0, false, -640, 480)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation0, true, 0, 480)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation90, false, 0, 480)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation90, true, 0, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation180, false, 0, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation180, true, -640, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation270, false, -640, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation270, true, -640, 480)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation0, false, 0, 240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation0, true, 640, 240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation90, false, 640, 240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation90, true, 640, -240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation180, false, 640, -240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation180, true, 0, -240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation270, false, 0, -240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation270, true, 0, 240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation0, false, -320, 240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation0, true, 320, 240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation90, false, 320, 240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation90, true, 320, -240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation180, false, 320, -240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation180, true, -320, -240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation270, false, -320, -240)]
+    [TestCase(640, 480, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation270, true, -320, 240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation0, false, -640, 240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation0, true, 0, 240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation90, false, 0, 240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation90, true, 0, -240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation180, false, 0, -240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation180, true, -640, -240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation270, false, -640, -240)]
+    [TestCase(640, 480, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation270, true, -640, 240)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation0, false, 0, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation0, true, 640, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation90, false, 640, 0)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation90, true, 640, -480)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation180, false, 640, -480)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation180, true, 0, -480)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation270, false, 0, -480)]
+    [TestCase(640, 480, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation270, true, 0, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation0, false, -320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation0, true, 320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation90, false, 320, 0)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation90, true, 320, -480)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation180, false, 320, -480)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation180, true, -320, -480)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation270, false, -320, -480)]
+    [TestCase(640, 480, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation270, true, -320, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation0, false, -640, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation0, true, 0, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation90, false, 0, 0)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation90, true, 0, -480)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation180, false, 0, -480)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation180, true, -640, -480)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation270, false, -640, -480)]
+    [TestCase(640, 480, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation270, true, -640, 0)]
+    public void ImageToPoint_ShouldReturnLocalPoint_When_TheAnchorOfRectIsNotAtTheCenter(int width, int height, int x, int y, float xMin, float xMax, float yMin, float yMax,
+                                                                                         RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY)
+    {
+      var rect = BuildRect(xMin, xMax, yMin, yMax);
+      var result = ImageCoordinate.ImageToPoint(rect, x, y, width, height, imageRotation, isMirrored);
+      Assert.AreEqual(new Vector3(expectedX, expectedY, 0), result);
     }
     #endregion
 
@@ -261,6 +337,33 @@ namespace Tests
 #pragma warning disable IDE0002
       GameObject.DestroyImmediate(gameObject);
 #pragma warning restore IDE0002
+    }
+
+    private UnityEngine.Rect BuildRect(float xMin, float xMax, float yMin, float yMax)
+    {
+      var x = xMax < 0 ? xMin : -xMax;
+      var y = yMax < 0 ? yMin : -yMax;
+      var rect = new UnityEngine.Rect(x, y, -2 * x, -2 * y);
+
+      if (xMax < 0)
+      {
+        rect.xMax = xMax;
+      }
+      else
+      {
+        rect.xMin = xMin;
+      }
+
+      if (yMax < 0)
+      {
+        rect.yMax = yMax;
+      }
+      else
+      {
+        rect.yMin = yMin;
+      }
+
+      return rect;
     }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
@@ -13,7 +13,7 @@ namespace Tests
 {
   public class ImageCoordinateTest
   {
-    #region ImageToLocalPoint
+    #region ImageToPoint
     [TestCase(640, 480, -160, 0, 10, RotationAngle.Rotation0, false, -480, 240, 10)]
     [TestCase(640, 480, 0, -160, 10, RotationAngle.Rotation0, false, -320, 400, 10)]
     [TestCase(640, 480, 800, 0, 10, RotationAngle.Rotation0, false, 480, 240, 10)]
@@ -207,7 +207,7 @@ namespace Tests
     }
     #endregion
 
-    #region GetLocalPositionNormalized
+    #region ImageNormalizedToPoint
     [TestCase(640, 480, -0.25f, 0, 0, RotationAngle.Rotation0, false, -480, 240, 0)]
     [TestCase(640, 480, 0, -0.25f, 0, RotationAngle.Rotation0, false, -320, 360, 0)]
     [TestCase(640, 480, 1.25f, 0, 1, RotationAngle.Rotation0, false, 480, 240, 640)]
@@ -272,14 +272,92 @@ namespace Tests
     [TestCase(640, 480, 0, 1.25f, -1, RotationAngle.Rotation270, true, 480, 240, -480)]
     [TestCase(640, 480, 1.25f, 1, 0, RotationAngle.Rotation270, true, 320, -360, 0)]
     [TestCase(640, 480, 1, 1.25f, 0, RotationAngle.Rotation270, true, 480, -240, 0)]
-    public void GetLocalPositionNormalized_ShouldReturnLocalPosition_When_ImageRotationAndIsMirroredAreSpecified(int width, int height, float normalizedX, float normalizedY, float normalizedZ, RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
+    public void ImageNormalizedToPoint_ShouldReturnLocalPoint_When_TheAnchorOfRectIsAtTheCenter(int width, int height, float normalizedX, float normalizedY, float normalizedZ,
+                                                                                                RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
     {
-      WithRectTransform((rectTransform) =>
-      {
-        rectTransform.sizeDelta = new Vector2(width, height);
-        var result = ImageCoordinate.GetLocalPositionNormalized(rectTransform, normalizedX, normalizedY, normalizedZ, imageRotation, isMirrored);
-        Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
-      });
+      var rect = BuildRect(-width / 2, width / 2, -height / 2, height / 2);
+      var result = ImageCoordinate.ImageNormalizedToPoint(rect, normalizedX, normalizedY, normalizedZ, imageRotation, isMirrored);
+      Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
+    }
+
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation0, false, 0, 480, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation0, true, 640, 480, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation90, false, 640, 480, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation90, true, 640, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation180, false, 640, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation180, true, 0, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation270, false, 0, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, 0, 480, RotationAngle.Rotation270, true, 0, 480, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation0, false, -320, 480, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation0, true, 320, 480, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation90, false, 320, 480, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation90, true, 320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation180, false, 320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation180, true, -320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation270, false, -320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, 0, 480, RotationAngle.Rotation270, true, -320, 480, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation0, false, -640, 480, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation0, true, 0, 480, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation90, false, 0, 480, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation90, true, 0, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation180, false, 0, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation180, true, -640, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation270, false, -640, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, 0, 480, RotationAngle.Rotation270, true, -640, 480, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation0, false, 0, 240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation0, true, 640, 240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation90, false, 640, 240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation90, true, 640, -240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation180, false, 640, -240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation180, true, 0, -240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation270, false, 0, -240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -240, 240, RotationAngle.Rotation270, true, 0, 240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation0, false, -320, 240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation0, true, 320, 240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation90, false, 320, 240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation90, true, 320, -240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation180, false, 320, -240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation180, true, -320, -240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation270, false, -320, -240, 0)]
+    [TestCase(0, 0, 0, -320, 320, -240, 240, RotationAngle.Rotation270, true, -320, 240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation0, false, -640, 240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation0, true, 0, 240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation90, false, 0, 240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation90, true, 0, -240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation180, false, 0, -240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation180, true, -640, -240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation270, false, -640, -240, 0)]
+    [TestCase(0, 0, 0, -640, 0, -240, 240, RotationAngle.Rotation270, true, -640, 240, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation0, false, 0, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation0, true, 640, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation90, false, 640, 0, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation90, true, 640, -480, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation180, false, 640, -480, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation180, true, 0, -480, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation270, false, 0, -480, 0)]
+    [TestCase(0, 0, 0, 0, 640, -480, 0, RotationAngle.Rotation270, true, 0, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation0, false, -320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation0, true, 320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation90, false, 320, 0, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation90, true, 320, -480, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation180, false, 320, -480, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation180, true, -320, -480, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation270, false, -320, -480, 0)]
+    [TestCase(0, 0, 0, -320, 320, -480, 0, RotationAngle.Rotation270, true, -320, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation0, false, -640, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation0, true, 0, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation90, false, 0, 0, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation90, true, 0, -480, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation180, false, 0, -480, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation180, true, -640, -480, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation270, false, -640, -480, 0)]
+    [TestCase(0, 0, 0, -640, 0, -480, 0, RotationAngle.Rotation270, true, -640, 0, 0)]
+    public void ImageNormalizedToPoint_ShouldReturnLocalPoint_When_TheAnchorOfRectIsNotAtTheCenter(float normalizedX, float normalizedY, float normalizedZ, float xMin, float xMax, float yMin, float yMax,
+                                                                                                   RotationAngle imageRotation, bool isMirrored, float expectedX, float expectedY, float expectedZ)
+    {
+      var rect = BuildRect(xMin, xMax, yMin, yMax);
+      var result = ImageCoordinate.ImageNormalizedToPoint(rect, normalizedX, normalizedY, normalizedZ, imageRotation, isMirrored);
+      Assert.AreEqual(new Vector3(expectedX, expectedY, expectedZ), result);
     }
 
     [TestCase(640, 480, 0, 0, 1, 100, RotationAngle.Rotation0, false, 100)]
@@ -314,36 +392,20 @@ namespace Tests
     [TestCase(640, 480, 0, 0, 0.5f, 100, RotationAngle.Rotation270, true, 50)]
     [TestCase(640, 480, 0, 0, -1, 100, RotationAngle.Rotation270, true, -100)]
     [TestCase(640, 480, 0, 0, -0.5f, 100, RotationAngle.Rotation270, true, -50)]
-    public void GetLocalPositionNormalized_ShouldScaleZ_When_ZScaleIsSpecified(int width, int height, float normalizedX, float normalizedY, float normalizedZ, float zScale, RotationAngle imageRotation, bool isMirrored, float expectedZ)
+    public void ImageNormalizedToPoint_ShouldReturnLocalPoint_When_ZScaleIsSpecified(int width, int height, float normalizedX, float normalizedY, float normalizedZ, float zScale,
+                                                                                     RotationAngle imageRotation, bool isMirrored, float expectedZ)
     {
-      WithRectTransform((rectTransform) =>
-      {
-        rectTransform.sizeDelta = new Vector2(width, height);
-        var result = ImageCoordinate.GetLocalPositionNormalized(rectTransform, normalizedX, normalizedY, normalizedZ, zScale, imageRotation, isMirrored);
-        Assert.AreEqual(expectedZ, result.z);
-      });
+      var rect = BuildRect(-width / 2, width / 2, -height / 2, height / 2);
+      var result = ImageCoordinate.ImageNormalizedToPoint(rect, normalizedX, normalizedY, normalizedZ, zScale, imageRotation, isMirrored);
+      Assert.AreEqual(expectedZ, result.z);
     }
     #endregion
 
-    private void WithRectTransform(System.Action<RectTransform> action)
-    {
-      var gameObject = new GameObject();
-      var rectTransform = gameObject.AddComponent<RectTransform>();
-      rectTransform.pivot = 0.5f * Vector2.one;
-      rectTransform.anchorMin = 0.5f * Vector2.one;
-      rectTransform.anchorMax = 0.5f * Vector2.one;
-
-      action(rectTransform);
-#pragma warning disable IDE0002
-      GameObject.DestroyImmediate(gameObject);
-#pragma warning restore IDE0002
-    }
-
-    private UnityEngine.Rect BuildRect(float xMin, float xMax, float yMin, float yMax)
+    private Rect BuildRect(float xMin, float xMax, float yMin, float yMax)
     {
       var x = xMax < 0 ? xMin : -xMax;
       var y = yMax < 0 ? yMin : -yMax;
-      var rect = new UnityEngine.Rect(x, y, -2 * x, -2 * y);
+      var rect = new Rect(x, y, -2 * x, -2 * y);
 
       if (xMax < 0)
       {


### PR DESCRIPTION
Rename coordinate transform methods and add some missing helper methods.

- `ImageCoordinateSystem.GetLocalPosition` -> `ImageCoordinateSystem.ImageToLocalPoint`
- `RealWorldCoordinateSystem.GetLocalPosition` -> `RealWorldCoordinateSystem.RealWorldToLocalPoint`
- `CameraCoordinateSystem.GetLocalPosition` -> `CameraCoordinateSystem.CameraToLocalPoint`
- Add `CameraCoordinateSystem.GetApproximateQuaternion`