### PR TITLE
refactor!: callback functions return StatusArgs instead of Status

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
@@ -13,8 +13,8 @@ namespace Mediapipe
 {
   public class CalculatorGraph : MpResourceHandle
   {
-    public delegate IntPtr NativePacketCallback(IntPtr graphPtr, int streamId, IntPtr packetPtr);
-    public delegate Status PacketCallback<TPacket, TValue>(TPacket packet) where TPacket : Packet<TValue>;
+    public delegate Status.StatusArgs NativePacketCallback(IntPtr graphPtr, int streamId, IntPtr packetPtr);
+    public delegate void PacketCallback<TPacket, TValue>(TPacket packet) where TPacket : Packet<TValue>;
 
     public CalculatorGraph() : base()
     {
@@ -83,13 +83,13 @@ namespace Mediapipe
         try
         {
           var packet = Packet<TValue>.Create<TPacket>(packetPtr, false);
-          status = packetCallback(packet);
+          return Status.StatusArgs.Ok();
         }
         catch (Exception e)
         {
           status = Status.FailedPrecondition(e.ToString());
+          return Status.StatusArgs.Internal(e.ToString());
         }
-        return status.mpPtr;
       };
       callbackHandle = GCHandle.Alloc(nativePacketCallback, GCHandleType.Pinned);
 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/CalculatorGraph.cs
@@ -79,15 +79,14 @@ namespace Mediapipe
     {
       NativePacketCallback nativePacketCallback = (IntPtr graphPtr, int streamId, IntPtr packetPtr) =>
       {
-        Status status = null;
         try
         {
           var packet = Packet<TValue>.Create<TPacket>(packetPtr, false);
+          packetCallback(packet);
           return Status.StatusArgs.Ok();
         }
         catch (Exception e)
         {
-          status = Status.FailedPrecondition(e.ToString());
           return Status.StatusArgs.Internal(e.ToString());
         }
       };

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Port/Status.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Port/Status.cs
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Mediapipe
 {
@@ -29,6 +30,104 @@ namespace Mediapipe
       Unavailable = 14,
       DataLoss = 15,
       Unauthenticated = 16,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct StatusArgs
+    {
+      public StatusCode code;
+      public string message;
+
+      private StatusArgs(StatusCode code, string message = null)
+      {
+        this.code = code;
+        this.message = message;
+      }
+
+      public static StatusArgs Ok()
+      {
+        return new StatusArgs(StatusCode.Ok);
+      }
+
+      public static StatusArgs Cancelled(string message = null)
+      {
+        return new StatusArgs(StatusCode.Cancelled, message);
+      }
+
+      public static StatusArgs Unknown(string message = null)
+      {
+        return new StatusArgs(StatusCode.Unknown, message);
+      }
+
+      public static StatusArgs InvalidArgument(string message = null)
+      {
+        return new StatusArgs(StatusCode.InvalidArgument, message);
+      }
+
+      public static StatusArgs DeadlineExceeded(string message = null)
+      {
+        return new StatusArgs(StatusCode.DeadlineExceeded, message);
+      }
+
+      public static StatusArgs NotFound(string message = null)
+      {
+        return new StatusArgs(StatusCode.NotFound, message);
+      }
+
+      public static StatusArgs AlreadyExists(string message = null)
+      {
+        return new StatusArgs(StatusCode.AlreadyExists, message);
+      }
+
+      public static StatusArgs PermissionDenied(string message = null)
+      {
+        return new StatusArgs(StatusCode.PermissionDenied, message);
+      }
+
+      public static StatusArgs ResourceExhausted(string message = null)
+      {
+        return new StatusArgs(StatusCode.ResourceExhausted, message);
+      }
+
+      public static StatusArgs FailedPrecondition(string message = null)
+      {
+        return new StatusArgs(StatusCode.FailedPrecondition, message);
+      }
+
+      public static StatusArgs Aborted(string message = null)
+      {
+        return new StatusArgs(StatusCode.Aborted, message);
+      }
+
+      public static StatusArgs OutOfRange(string message = null)
+      {
+        return new StatusArgs(StatusCode.OutOfRange, message);
+      }
+
+      public static StatusArgs Unimplemented(string message = null)
+      {
+        return new StatusArgs(StatusCode.Unimplemented, message);
+      }
+
+      public static StatusArgs Internal(string message = null)
+      {
+        return new StatusArgs(StatusCode.Internal, message);
+      }
+
+      public static StatusArgs Unavailable(string message = null)
+      {
+        return new StatusArgs(StatusCode.Unavailable, message);
+      }
+
+      public static StatusArgs DataLoss(string message = null)
+      {
+        return new StatusArgs(StatusCode.DataLoss, message);
+      }
+
+      public static StatusArgs Unauthenticated(string message = null)
+      {
+        return new StatusArgs(StatusCode.Unauthenticated, message);
+      }
     }
 
     public Status(IntPtr ptr, bool isOwner = true) : base(ptr, isOwner) { }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Port/Status.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Port/Status.cs
@@ -33,15 +33,15 @@ namespace Mediapipe
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct StatusArgs
+    public readonly struct StatusArgs
     {
-      public StatusCode code;
-      public string message;
+      private readonly StatusCode _code;
+      private readonly IntPtr _message;
 
       private StatusArgs(StatusCode code, string message = null)
       {
-        this.code = code;
-        this.message = message;
+        _code = code;
+        _message = Marshal.StringToHGlobalAnsi(message);
       }
 
       public static StatusArgs Ok()

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GlCalculatorHelper.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GlCalculatorHelper.cs
@@ -11,8 +11,8 @@ namespace Mediapipe
 
   public class GlCalculatorHelper : MpResourceHandle
   {
-    public delegate IntPtr NativeGlStatusFunction();
-    public delegate Status GlStatusFunction();
+    public delegate Status.StatusArgs NativeGlStatusFunction();
+    public delegate void GlFunction();
 
     public GlCalculatorHelper() : base()
     {
@@ -45,26 +45,20 @@ namespace Mediapipe
       return new Status(statusPtr);
     }
 
-    public Status RunInGlContext(GlStatusFunction glStatusFunc)
+    public Status RunInGlContext(GlFunction glStatusFunc)
     {
-      Status tmpStatus = null;
-
-      var status = RunInGlContext(() =>
+      return RunInGlContext(() =>
       {
         try
         {
-          tmpStatus = glStatusFunc();
+          glStatusFunc();
+          return Status.StatusArgs.Ok();
         }
         catch (Exception e)
         {
-          tmpStatus = Status.FailedPrecondition(e.ToString());
+          return Status.StatusArgs.Internal(e.ToString());
         }
-        return tmpStatus.mpPtr;
       });
-
-      if (tmpStatus != null) { tmpStatus.Dispose(); }
-
-      return status;
     }
 
     public GlTexture CreateSourceTexture(ImageFrame imageFrame)

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/UnsafeNativeMethods.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/UnsafeNativeMethods.cs
@@ -4,7 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+using System;
 using System.Security;
+using System.Runtime.InteropServices;
 
 namespace Mediapipe
 {
@@ -21,5 +23,21 @@ namespace Mediapipe
 #else
       "mediapipe_c";
 #endif
+
+    static UnsafeNativeMethods()
+    {
+      mp_api__SetFreeHGlobal(FreeHGlobal);
+    }
+
+    internal delegate void FreeHGlobalDelegate(IntPtr hglobal);
+
+    [AOT.MonoPInvokeCallback(typeof(FreeHGlobalDelegate))]
+    private static void FreeHGlobal(IntPtr hglobal)
+    {
+      Marshal.FreeHGlobal(hglobal);
+    }
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern void mp_api__SetFreeHGlobal([MarshalAs(UnmanagedType.FunctionPtr)] FreeHGlobalDelegate freeHGlobal);
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
@@ -5,9 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Mediapipe.Unity
 {
@@ -25,16 +23,6 @@ namespace Mediapipe.Unity
   {
     private static int _Counter = 0;
     private static readonly GlobalInstanceTable<int, OutputStream<TPacket, TValue>> _InstanceTable = new GlobalInstanceTable<int, OutputStream<TPacket, TValue>>(20);
-
-    /// <summary>
-    ///   Store the last <see cref="Status" /> to prevent it from being GCed while it is used by the Unmanaged Code.<br />
-    ///   This member variable's key is a stream ID, but if the corresponding <see cref="OutputStream" /> instance exists,
-    ///   the last <see cref="Status" /> will be stored in <see cref="_callbackStatus" /> instead.
-    /// </summary>
-    /// <remarks>
-    ///   We may need to store multiple instances (e.g. using ring buffers) if the packet callback can be called from multiple threads at the same time.
-    /// </remarks>
-    private static readonly Dictionary<int, Status> _CallbackStatus = new Dictionary<int, Status>();
 
     protected readonly CalculatorGraph calculatorGraph;
 
@@ -72,14 +60,6 @@ namespace Mediapipe.Unity
       }
     }
 
-    /// <summary>
-    ///   Store the last <see cref="Status" /> to prevent it from being GCed while it is used by the Unmanaged Code.
-    /// </summary>
-    /// <remarks>
-    ///   We may need to store multiple instances (e.g. using ring buffers) if the packet callback can be called from multiple threads at the same time.
-    /// </remarks>
-    private Status _callbackStatus;
-
     protected bool canTestPresence => presenceStreamName != null;
 
     /// <summary>
@@ -109,7 +89,6 @@ namespace Mediapipe.Unity
       this.timeoutMicrosec = timeoutMicrosec;
 
       _InstanceTable.Add(_id, this);
-      CompressCallbackStatus();
     }
 
     /// <summary>
@@ -181,7 +160,6 @@ namespace Mediapipe.Unity
     public void Close()
     {
       RemoveAllListeners();
-      RemoveCallbackStatus();
 
       _poller?.Dispose();
       _poller = null;
@@ -424,58 +402,6 @@ namespace Mediapipe.Unity
       catch (Exception e)
       {
         return Status.StatusArgs.Internal(e.ToString());
-      }
-    }
-
-    /// <summary>
-    ///   To prevent <paramref name="status" /> from being GCed, store it in <see cref="_CallbackStatus" />.
-    /// </summary>
-    /// <remarks>
-    ///   Prefer the instance method with the same name.
-    /// </remarks>
-    protected static IntPtr GetPinnedStatusPtr(int streamId, Status status)
-    {
-      lock (((ICollection)_CallbackStatus).SyncRoot)
-      {
-        _CallbackStatus[streamId] = status;
-        return status.mpPtr;
-      }
-    }
-
-    /// <summary>
-    ///   To prevent <paramref name="status" /> from being GCed, store it in <see cref="_callbackStatus" />.
-    /// </summary>
-    protected IntPtr GetPinnedStatusPtr(Status status)
-    {
-      _callbackStatus = status;
-      return _callbackStatus.mpPtr;
-    }
-
-    protected void RemoveCallbackStatus()
-    {
-      _callbackStatus?.Dispose();
-      _callbackStatus = null;
-
-      lock (((ICollection)_CallbackStatus).SyncRoot)
-      {
-        if (_CallbackStatus.TryGetValue(_id, out var status))
-        {
-          status.Dispose();
-        }
-        var _ = _CallbackStatus.Remove(_id);
-      }
-    }
-
-    protected static void CompressCallbackStatus()
-    {
-      lock (((ICollection)_CallbackStatus).SyncRoot)
-      {
-        var deadKeys = _CallbackStatus.Where(x => !_InstanceTable.ContainsKey(x.Key)).Select(x => x.Key).ToArray();
-
-        foreach (var key in deadKeys)
-        {
-          var _ = _CallbackStatus.Remove(key);
-        }
       }
     }
   }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/OutputStream.cs
@@ -398,18 +398,18 @@ namespace Mediapipe.Unity
     }
 
     [AOT.MonoPInvokeCallback(typeof(CalculatorGraph.NativePacketCallback))]
-    protected static IntPtr InvokeIfOutputStreamFound(IntPtr graphPtr, int streamId, IntPtr packetPtr)
+    protected static Status.StatusArgs InvokeIfOutputStreamFound(IntPtr graphPtr, int streamId, IntPtr packetPtr)
     {
       try
       {
         var isFound = _InstanceTable.TryGetValue(streamId, out var outputStream);
         if (!isFound)
         {
-          return GetPinnedStatusPtr(streamId, Status.FailedPrecondition($"OutputStream with id {streamId} is not found"));
+          return Status.StatusArgs.NotFound($"OutputStream with id {streamId} is not found");
         }
         if (outputStream.calculatorGraph.mpPtr != graphPtr)
         {
-          return GetPinnedStatusPtr(streamId, Status.FailedPrecondition($"OutputStream is found, but is not linked to the specified CalclatorGraph"));
+          return Status.StatusArgs.InvalidArgument($"OutputStream is found, but is not linked to the specified CalclatorGraph");
         }
 
         outputStream.referencePacket.SwitchNativePtr(packetPtr);
@@ -419,11 +419,11 @@ namespace Mediapipe.Unity
         }
         outputStream.referencePacket.ReleaseMpResource();
 
-        return outputStream.GetPinnedStatusPtr(Status.Ok());
+        return Status.StatusArgs.Ok();
       }
       catch (Exception e)
       {
-        return GetPinnedStatusPtr(streamId, Status.FailedPrecondition(e.ToString()));
+        return Status.StatusArgs.Internal(e.ToString());
       }
     }
 

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
@@ -64,35 +64,20 @@ namespace Tests
       {
         glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
-        var status = glCalculatorHelper.RunInGlContext(() => { return Status.Ok(); });
+        var status = glCalculatorHelper.RunInGlContext(() => { });
         Assert.True(status.Ok());
       }
     }
 
     [Test, GpuOnly]
-    public void RunInGlContext_ShouldReturnInternal_When_FunctionReturnsInternal()
+    public void RunInGlContext_ShouldReturnInternal_When_FunctionThrows()
     {
       using (var glCalculatorHelper = new GlCalculatorHelper())
       {
         glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
-        var status = glCalculatorHelper.RunInGlContext(() => { return Status.Build(Status.StatusCode.Internal, "error"); });
+        var status = glCalculatorHelper.RunInGlContext((GlCalculatorHelper.GlFunction)(() => { throw new Exception("Function Throws"); }));
         Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
-      }
-    }
-
-    [Test, GpuOnly]
-    public void RunInGlContext_ShouldReturnFailedPreCondition_When_FunctionThrows()
-    {
-      using (var glCalculatorHelper = new GlCalculatorHelper())
-      {
-        glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
-
-#pragma warning disable IDE0039
-        GlCalculatorHelper.GlStatusFunction glStatusFunction = () => { throw new InvalidProgramException(); };
-#pragma warning restore IDE0039
-        var status = glCalculatorHelper.RunInGlContext(glStatusFunction);
-        Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
       }
     }
     #endregion
@@ -115,7 +100,6 @@ namespace Tests
             Assert.AreEqual(texture.height, 24);
 
             texture.Dispose();
-            return Status.Ok();
           });
           Assert.True(status.Ok());
 
@@ -140,7 +124,6 @@ namespace Tests
             {
               texture.Release();
             }
-            return Status.Ok();
           });
           Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
 
@@ -164,7 +147,6 @@ namespace Tests
 
           Assert.AreEqual(glTexture.width, 32);
           Assert.AreEqual(glTexture.height, 24);
-          return Status.Ok();
         });
 
         Assert.True(status.Ok());

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
@@ -34,7 +34,6 @@ namespace Tests
           {
             Assert.NotNull(glContext);
             Assert.True(glContext.IsCurrent());
-            return Status.Ok();
           }
         }).AssertOk();
       }

--- a/mediapipe_api/common.cc
+++ b/mediapipe_api/common.cc
@@ -12,3 +12,11 @@ thread_local sigjmp_buf mp_api::abrt_jbuf;
 
 void mp_api::sigabrt_handler(int sig) { siglongjmp(abrt_jbuf, 1); }
 #endif
+
+namespace mp_api {
+  FreeHGlobal* freeHGlobal;
+}
+
+void mp_api__SetFreeHGlobal(mp_api::FreeHGlobal* freeHGlobal) {
+  mp_api::freeHGlobal = freeHGlobal;
+}

--- a/mediapipe_api/common.h
+++ b/mediapipe_api/common.h
@@ -46,6 +46,10 @@ struct StructArray {
   int size;
 };
 
+typedef void FreeHGlobal(void* hglobal);
+
+extern FreeHGlobal* freeHGlobal;
+
 #if defined(_WIN32) || defined(__EMSCRIPTEN__)
 #define MEDIAPIPE_DISABLE_SIGABRT_HANDLER
 #endif
@@ -126,4 +130,11 @@ extern void sigabrt_handler(int sig);
 #endif  // _WIN32
 
 #define MP_CAPI(rettype) MP_CAPI_EXPORT extern rettype CDECL
+
+extern "C" {
+
+MP_CAPI(void) mp_api__SetFreeHGlobal(mp_api::FreeHGlobal* freeHGlobal);
+
+}  // extern "C"
+
 #endif  // MEDIAPIPE_API_COMMON_H_

--- a/mediapipe_api/external/absl/status.h
+++ b/mediapipe_api/external/absl/status.h
@@ -10,6 +10,15 @@
 #include "absl/status/status.h"
 #include "mediapipe_api/common.h"
 
+namespace mp_api {
+
+typedef struct StatusArgs {
+  absl::StatusCode code;
+  void* message;
+};
+
+}  // namespace mp_api
+
 extern "C" {
 
 MP_CAPI(MpReturnCode) absl_Status__i_PKc(int code, const char* message, absl::Status** status_out);

--- a/mediapipe_api/framework/calculator_graph.cc
+++ b/mediapipe_api/framework/calculator_graph.cc
@@ -64,7 +64,9 @@ MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(mediapipe::Calcul
         stream_name,
         [graph, stream_id, packet_callback](const mediapipe::Packet& packet) -> ::absl::Status {
           auto status_args = packet_callback(graph, stream_id, packet);
-          return absl::Status{status_args.code, absl::NullSafeStringView(status_args.message)};
+          auto callback_status = absl::Status{status_args.code, absl::NullSafeStringView((const char*)status_args.message)};
+          mp_api::freeHGlobal(status_args.message);
+          return std::move(callback_status);
         },
         observe_timestamp_bounds);
     *status_out = new absl::Status{std::move(status)};

--- a/mediapipe_api/framework/calculator_graph.cc
+++ b/mediapipe_api/framework/calculator_graph.cc
@@ -65,7 +65,9 @@ MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(mediapipe::Calcul
         [graph, stream_id, packet_callback](const mediapipe::Packet& packet) -> ::absl::Status {
           auto status_args = packet_callback(graph, stream_id, packet);
           auto callback_status = absl::Status{status_args.code, absl::NullSafeStringView((const char*)status_args.message)};
-          mp_api::freeHGlobal(status_args.message);
+          if (status_args.message != nullptr) {
+            mp_api::freeHGlobal(status_args.message);
+          }
           return std::move(callback_status);
         },
         observe_timestamp_bounds);

--- a/mediapipe_api/framework/calculator_graph.cc
+++ b/mediapipe_api/framework/calculator_graph.cc
@@ -63,7 +63,8 @@ MpReturnCode mp_CalculatorGraph__ObserveOutputStream__PKc_PF_b(mediapipe::Calcul
     auto status = graph->ObserveOutputStream(
         stream_name,
         [graph, stream_id, packet_callback](const mediapipe::Packet& packet) -> ::absl::Status {
-          return absl::Status{std::move(*packet_callback(graph, stream_id, packet))};
+          auto status_args = packet_callback(graph, stream_id, packet);
+          return absl::Status{status_args.code, absl::NullSafeStringView(status_args.message)};
         },
         observe_timestamp_bounds);
     *status_out = new absl::Status{std::move(status)};

--- a/mediapipe_api/framework/calculator_graph.h
+++ b/mediapipe_api/framework/calculator_graph.h
@@ -26,13 +26,7 @@
 extern "C" {
 
 typedef std::map<std::string, mediapipe::Packet> SidePackets;
-
-typedef struct StatusArgs {
-  absl::StatusCode code;
-  const char* message;
-};
-
-typedef StatusArgs NativePacketCallback(mediapipe::CalculatorGraph* graph, int stream_id, const mediapipe::Packet&);
+typedef mp_api::StatusArgs NativePacketCallback(mediapipe::CalculatorGraph* graph, int stream_id, const mediapipe::Packet&);
 
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__(mediapipe::CalculatorGraph** graph_out);
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__PKc_i(const char* serialized_config, int size, mediapipe::CalculatorGraph** graph_out);

--- a/mediapipe_api/framework/calculator_graph.h
+++ b/mediapipe_api/framework/calculator_graph.h
@@ -26,7 +26,13 @@
 extern "C" {
 
 typedef std::map<std::string, mediapipe::Packet> SidePackets;
-typedef absl::Status* NativePacketCallback(mediapipe::CalculatorGraph* graph, int stream_id, const mediapipe::Packet&);
+
+typedef struct StatusArgs {
+  absl::StatusCode code;
+  const char* message;
+};
+
+typedef StatusArgs NativePacketCallback(mediapipe::CalculatorGraph* graph, int stream_id, const mediapipe::Packet&);
 
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__(mediapipe::CalculatorGraph** graph_out);
 MP_CAPI(MpReturnCode) mp_CalculatorGraph__PKc_i(const char* serialized_config, int size, mediapipe::CalculatorGraph** graph_out);

--- a/mediapipe_api/gpu/gl_calculator_helper.cc
+++ b/mediapipe_api/gpu/gl_calculator_helper.cc
@@ -28,7 +28,10 @@ MpReturnCode mp_GlCalculatorHelper__RunInGlContext__PF(mediapipe::GlCalculatorHe
                                                        absl::Status** status_out) {
   TRY
     auto status = gl_calculator_helper->RunInGlContext([&gl_func]() -> ::absl::Status {
-      return absl::Status{std::move(*(gl_func()))};
+      auto status_args = gl_func();
+      auto gl_status = absl::Status{status_args.code, absl::NullSafeStringView((const char*)status_args.message)};
+      mp_api::freeHGlobal(status_args.message);
+      return std::move(gl_status);
     });
     *status_out = new absl::Status{std::move(status)};
     RETURN_CODE(MpReturnCode::Success);

--- a/mediapipe_api/gpu/gl_calculator_helper.cc
+++ b/mediapipe_api/gpu/gl_calculator_helper.cc
@@ -30,7 +30,9 @@ MpReturnCode mp_GlCalculatorHelper__RunInGlContext__PF(mediapipe::GlCalculatorHe
     auto status = gl_calculator_helper->RunInGlContext([&gl_func]() -> ::absl::Status {
       auto status_args = gl_func();
       auto gl_status = absl::Status{status_args.code, absl::NullSafeStringView((const char*)status_args.message)};
-      mp_api::freeHGlobal(status_args.message);
+      if (status_args.message != nullptr) {
+        mp_api::freeHGlobal(status_args.message);
+      }
       return std::move(gl_status);
     });
     *status_out = new absl::Status{std::move(status)};

--- a/mediapipe_api/gpu/gl_calculator_helper.h
+++ b/mediapipe_api/gpu/gl_calculator_helper.h
@@ -15,7 +15,7 @@
 
 extern "C" {
 
-typedef absl::Status* NativeGlStatusFunction();
+typedef mp_api::StatusArgs NativeGlStatusFunction();
 
 /** GlCalculatorHelper API */
 MP_CAPI(MpReturnCode) mp_GlCalculatorHelper__(mediapipe::GlCalculatorHelper** gl_calculator_helper_out);


### PR DESCRIPTION
fix #417

#417 seemed to occur because `NativePacketCallback` returns a pointer to a resource that is managed by the Managed Code, but its lifetime is only known to the Unmanaged Code.
#563 resolved it by pinning the resource for a while, but it's still unclear how long it should be pinned.

This PR allows the returned resource to be explicitly released by the Unmanaged Code, which will completely solve the issue.