### PR TITLE
chore: interchange the expected and actual arguments of Assert.AreEqual

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/CalculatorGraphTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/CalculatorGraphTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class CalculatorGraphTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/CalculatorGraphTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/CalculatorGraphTest.cs
@@ -5,7 +5,6 @@
 // https://opensource.org/licenses/MIT.
 
 using Mediapipe;
-using Mediapipe.Unity;
 using NUnit.Framework;
 
 namespace Tests
@@ -43,8 +42,8 @@ output_stream: ""out""
       using (var graph = new CalculatorGraph(_ValidConfigText))
       {
         var config = graph.Config();
-        Assert.AreEqual(config.InputStream[0], "in");
-        Assert.AreEqual(config.OutputStream[0], "out");
+        Assert.AreEqual("in", config.InputStream[0]);
+        Assert.AreEqual("out", config.OutputStream[0]);
       }
     }
     #endregion
@@ -81,8 +80,8 @@ output_stream: ""out""
         }
 
         var config = graph.Config();
-        Assert.AreEqual(config.InputStream[0], "in");
-        Assert.AreEqual(config.OutputStream[0], "out");
+        Assert.AreEqual("in", config.InputStream[0]);
+        Assert.AreEqual("out", config.OutputStream[0]);
       }
     }
 
@@ -93,7 +92,7 @@ output_stream: ""out""
       {
         using (var status = graph.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_ValidConfigText)))
         {
-          Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+          Assert.AreEqual(Status.StatusCode.Internal, status.Code());
         }
       }
     }
@@ -130,7 +129,7 @@ output_stream: ""out""
 
           using (var status = graph.Initialize(config, sidePacket))
           {
-            Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+            Assert.AreEqual(Status.StatusCode.Internal, status.Code());
           }
         }
       }
@@ -161,7 +160,7 @@ output_stream: ""out""
       {
         Assert.True(graph.StartRun().Ok());
         graph.Cancel();
-        Assert.AreEqual(graph.WaitUntilDone().Code(), Status.StatusCode.Cancelled);
+        Assert.AreEqual(Status.StatusCode.Cancelled, graph.WaitUntilDone().Code());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Format/ImageFrameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Format/ImageFrameTest.cs
@@ -20,19 +20,19 @@ namespace Tests
     {
       using (var imageFrame = new ImageFrame())
       {
-        Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Unknown);
-        Assert.AreEqual(imageFrame.Width(), 0);
-        Assert.AreEqual(imageFrame.Height(), 0);
-        Assert.AreEqual(imageFrame.ChannelSize(), 0);
-        Assert.AreEqual(imageFrame.NumberOfChannels(), 0);
-        Assert.AreEqual(imageFrame.ByteDepth(), 0);
-        Assert.AreEqual(imageFrame.WidthStep(), 0);
-        Assert.AreEqual(imageFrame.PixelDataSize(), 0);
-        Assert.AreEqual(imageFrame.PixelDataSizeStoredContiguously(), 0);
+        Assert.AreEqual(ImageFormat.Types.Format.Unknown, imageFrame.Format());
+        Assert.AreEqual(0, imageFrame.Width());
+        Assert.AreEqual(0, imageFrame.Height(), 0);
+        Assert.AreEqual(0, imageFrame.ChannelSize());
+        Assert.AreEqual(0, imageFrame.NumberOfChannels());
+        Assert.AreEqual(0, imageFrame.ByteDepth());
+        Assert.AreEqual(0, imageFrame.WidthStep());
+        Assert.AreEqual(0, imageFrame.PixelDataSize());
+        Assert.AreEqual(0, imageFrame.PixelDataSizeStoredContiguously());
         Assert.True(imageFrame.IsEmpty());
         Assert.False(imageFrame.IsContiguous());
         Assert.False(imageFrame.IsAligned(16));
-        Assert.AreEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+        Assert.AreEqual(IntPtr.Zero, imageFrame.MutablePixelData());
       }
     }
 
@@ -41,19 +41,19 @@ namespace Tests
     {
       using (var imageFrame = new ImageFrame(ImageFormat.Types.Format.Sbgra, 640, 480))
       {
-        Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Sbgra);
-        Assert.AreEqual(imageFrame.Width(), 640);
-        Assert.AreEqual(imageFrame.Height(), 480);
-        Assert.AreEqual(imageFrame.ChannelSize(), 1);
-        Assert.AreEqual(imageFrame.NumberOfChannels(), 4);
-        Assert.AreEqual(imageFrame.ByteDepth(), 1);
-        Assert.AreEqual(imageFrame.WidthStep(), 640 * 4);
-        Assert.AreEqual(imageFrame.PixelDataSize(), 640 * 480 * 4);
-        Assert.AreEqual(imageFrame.PixelDataSizeStoredContiguously(), 640 * 480 * 4);
+        Assert.AreEqual(ImageFormat.Types.Format.Sbgra, imageFrame.Format());
+        Assert.AreEqual(640, imageFrame.Width());
+        Assert.AreEqual(480, imageFrame.Height());
+        Assert.AreEqual(1, imageFrame.ChannelSize());
+        Assert.AreEqual(4, imageFrame.NumberOfChannels());
+        Assert.AreEqual(1, imageFrame.ByteDepth());
+        Assert.AreEqual(640 * 4, imageFrame.WidthStep());
+        Assert.AreEqual(640 * 480 * 4, imageFrame.PixelDataSize());
+        Assert.AreEqual(640 * 480 * 4, imageFrame.PixelDataSizeStoredContiguously());
         Assert.False(imageFrame.IsEmpty());
         Assert.True(imageFrame.IsContiguous());
         Assert.True(imageFrame.IsAligned(16));
-        Assert.AreNotEqual(imageFrame.MutablePixelData(), IntPtr.Zero);
+        Assert.AreNotEqual(IntPtr.Zero, imageFrame.MutablePixelData());
       }
     }
 
@@ -62,9 +62,9 @@ namespace Tests
     {
       using (var imageFrame = new ImageFrame(ImageFormat.Types.Format.Gray8, 100, 100, 8))
       {
-        Assert.AreEqual(imageFrame.Width(), 100);
-        Assert.AreEqual(imageFrame.NumberOfChannels(), 1);
-        Assert.AreEqual(imageFrame.WidthStep(), 104);
+        Assert.AreEqual(100, imageFrame.Width());
+        Assert.AreEqual(1, imageFrame.NumberOfChannels());
+        Assert.AreEqual(104, imageFrame.WidthStep());
       }
     }
 
@@ -80,8 +80,8 @@ namespace Tests
 
       using (var imageFrame = new ImageFrame(ImageFormat.Types.Format.Sbgra, 4, 2, 16, pixelData))
       {
-        Assert.AreEqual(imageFrame.Width(), 4);
-        Assert.AreEqual(imageFrame.Height(), 2);
+        Assert.AreEqual(4, imageFrame.Width());
+        Assert.AreEqual(2, imageFrame.Height());
         Assert.False(imageFrame.IsEmpty());
 
         var bytes = new byte[32];

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Format/ImageFrameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Format/ImageFrameTest.cs
@@ -4,13 +4,12 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 using System.Linq;
 using Unity.Collections;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class ImageFrameTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
@@ -19,9 +19,9 @@ namespace Tests
       using (var packet = new BoolPacket())
       {
 #pragma warning disable IDE0058
-        Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+        Assert.AreEqual(Status.StatusCode.Internal, packet.ValidateAsType().Code());
         Assert.Throws<MediaPipeException>(() => { packet.Get(); });
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
 #pragma warning restore IDE0058
       }
 
@@ -34,7 +34,7 @@ namespace Tests
       {
         Assert.True(packet.ValidateAsType().Ok());
         Assert.True(packet.Get());
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -45,7 +45,7 @@ namespace Tests
       {
         Assert.True(packet.ValidateAsType().Ok());
         Assert.False(packet.Get());
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -58,7 +58,7 @@ namespace Tests
         {
           Assert.True(packet.ValidateAsType().Ok());
           Assert.True(packet.Get());
-          Assert.AreEqual(packet.Timestamp(), timestamp);
+          Assert.AreEqual(timestamp, packet.Timestamp());
         }
       }
     }
@@ -92,16 +92,16 @@ namespace Tests
       {
         var packet = new BoolPacket(true).At(timestamp);
         Assert.True(packet.Get());
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
 
         using (var newTimestamp = new Timestamp(2))
         {
           var newPacket = packet.At(newTimestamp);
           Assert.True(newPacket.Get());
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+          Assert.AreEqual(newTimestamp, newPacket.Timestamp());
         }
 
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
       }
     }
     #endregion
@@ -125,7 +125,7 @@ namespace Tests
     {
       using (var packet = new BoolPacket(true))
       {
-        Assert.AreEqual(packet.DebugTypeName(), "bool");
+        Assert.AreEqual("bool", packet.DebugTypeName());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/BoolPacketTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class BoolPacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
@@ -20,9 +20,9 @@ namespace Tests
       {
 #pragma warning disable IDE0058
         packet.length = 0;
-        Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+        Assert.AreEqual(Status.StatusCode.Internal, packet.ValidateAsType().Code());
         Assert.Throws<MediaPipeException>(() => { packet.Get(); });
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
 #pragma warning restore IDE0058
       }
     }
@@ -34,8 +34,8 @@ namespace Tests
       using (var packet = new FloatArrayPacket(array))
       {
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Get(), array);
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(array, packet.Get());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -46,8 +46,8 @@ namespace Tests
       using (var packet = new FloatArrayPacket(array))
       {
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Get(), array);
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(array, packet.Get());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -60,8 +60,8 @@ namespace Tests
         using (var packet = new FloatArrayPacket(array, timestamp))
         {
           Assert.True(packet.ValidateAsType().Ok());
-          Assert.AreEqual(packet.Get(), array);
-          Assert.AreEqual(packet.Timestamp(), timestamp);
+          Assert.AreEqual(array, packet.Get());
+          Assert.AreEqual(timestamp, packet.Timestamp());
         }
       }
     }
@@ -95,17 +95,17 @@ namespace Tests
       {
         float[] array = { 0.0f };
         var packet = new FloatArrayPacket(array).At(timestamp);
-        Assert.AreEqual(packet.Get(), array);
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(array, packet.Get());
+        Assert.AreEqual(timestamp, packet.Timestamp());
 
         using (var newTimestamp = new Timestamp(2))
         {
           var newPacket = packet.At(newTimestamp);
-          Assert.AreEqual(newPacket.Get(), array);
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+          Assert.AreEqual(array, newPacket.Get());
+          Assert.AreEqual(newTimestamp, newPacket.Timestamp());
         }
 
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
       }
     }
     #endregion
@@ -130,7 +130,7 @@ namespace Tests
       float[] array = { 0.01f };
       using (var packet = new FloatArrayPacket(array))
       {
-        Assert.AreEqual(packet.DebugTypeName(), "float []");
+        Assert.AreEqual("float []", packet.DebugTypeName());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatArrayPacketTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class FloatArrayPacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class FloatPacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/FloatPacketTest.cs
@@ -19,9 +19,9 @@ namespace Tests
       using (var packet = new FloatPacket())
       {
 #pragma warning disable IDE0058
-        Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+        Assert.AreEqual(Status.StatusCode.Internal, packet.ValidateAsType().Code());
         Assert.Throws<MediaPipeException>(() => { packet.Get(); });
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
 #pragma warning restore IDE0058
       }
     }
@@ -32,8 +32,8 @@ namespace Tests
       using (var packet = new FloatPacket(0.01f))
       {
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Get(), 0.01f);
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(0.01f, packet.Get());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -45,8 +45,8 @@ namespace Tests
         using (var packet = new FloatPacket(0.01f, timestamp))
         {
           Assert.True(packet.ValidateAsType().Ok());
-          Assert.AreEqual(packet.Get(), 0.01f);
-          Assert.AreEqual(packet.Timestamp(), timestamp);
+          Assert.AreEqual(0.01f, packet.Get());
+          Assert.AreEqual(timestamp, packet.Timestamp());
         }
       }
     }
@@ -79,17 +79,17 @@ namespace Tests
       using (var timestamp = new Timestamp(1))
       {
         var packet = new FloatPacket(0).At(timestamp);
-        Assert.AreEqual(packet.Get(), 0.0f);
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(0.0f, packet.Get());
+        Assert.AreEqual(timestamp, packet.Timestamp());
 
         using (var newTimestamp = new Timestamp(2))
         {
           var newPacket = packet.At(newTimestamp);
-          Assert.AreEqual(newPacket.Get(), 0.0f);
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+          Assert.AreEqual(0.0f, newPacket.Get());
+          Assert.AreEqual(newTimestamp, newPacket.Timestamp());
         }
 
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
       }
     }
     #endregion
@@ -113,7 +113,7 @@ namespace Tests
     {
       using (var packet = new FloatPacket(0.01f))
       {
-        Assert.AreEqual(packet.DebugTypeName(), "float");
+        Assert.AreEqual("float", packet.DebugTypeName());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
@@ -19,9 +19,9 @@ namespace Tests
       {
         using (var statusOrImageFrame = packet.Consume())
         {
-          Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
-          Assert.AreEqual(statusOrImageFrame.status.Code(), Status.StatusCode.Internal);
-          Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+          Assert.AreEqual(Status.StatusCode.Internal, packet.ValidateAsType().Code());
+          Assert.AreEqual(Status.StatusCode.Internal, statusOrImageFrame.status.Code());
+          Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
         }
       }
     }
@@ -35,7 +35,7 @@ namespace Tests
       {
         Assert.True(srcImageFrame.isDisposed);
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
 
         using (var statusOrImageFrame = packet.Consume())
         {
@@ -43,7 +43,7 @@ namespace Tests
 
           using (var imageFrame = statusOrImageFrame.Value())
           {
-            Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Unknown);
+            Assert.AreEqual(ImageFormat.Types.Format.Unknown, imageFrame.Format());
           }
         }
       }
@@ -67,8 +67,8 @@ namespace Tests
 
             using (var imageFrame = statusOrImageFrame.Value())
             {
-              Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Unknown);
-              Assert.AreEqual(packet.Timestamp(), timestamp);
+              Assert.AreEqual(ImageFormat.Types.Format.Unknown, imageFrame.Format());
+              Assert.AreEqual(timestamp, packet.Timestamp());
             }
           }
         }
@@ -103,17 +103,17 @@ namespace Tests
       using (var timestamp = new Timestamp(1))
       {
         var packet = new ImageFramePacket(new ImageFrame(ImageFormat.Types.Format.Srgba, 10, 10)).At(timestamp);
-        Assert.AreEqual(packet.Get().Width(), 10);
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(10, packet.Get().Width());
+        Assert.AreEqual(timestamp, packet.Timestamp());
 
         using (var newTimestamp = new Timestamp(2))
         {
           var newPacket = packet.At(newTimestamp);
-          Assert.AreEqual(newPacket.Get().Width(), 10);
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+          Assert.AreEqual(10, newPacket.Get().Width());
+          Assert.AreEqual(newTimestamp, newPacket.Timestamp());
         }
 
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
       }
     }
     #endregion
@@ -136,9 +136,9 @@ namespace Tests
       {
         using (var imageFrame = packet.Get())
         {
-          Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Sbgra);
-          Assert.AreEqual(imageFrame.Width(), 10);
-          Assert.AreEqual(imageFrame.Height(), 10);
+          Assert.AreEqual(ImageFormat.Types.Format.Sbgra, imageFrame.Format());
+          Assert.AreEqual(10, imageFrame.Width());
+          Assert.AreEqual(10, imageFrame.Height());
         }
       }
     }
@@ -156,9 +156,9 @@ namespace Tests
 
           using (var imageFrame = statusOrImageFrame.Value())
           {
-            Assert.AreEqual(imageFrame.Format(), ImageFormat.Types.Format.Sbgra);
-            Assert.AreEqual(imageFrame.Width(), 10);
-            Assert.AreEqual(imageFrame.Height(), 10);
+            Assert.AreEqual(ImageFormat.Types.Format.Sbgra, imageFrame.Format());
+            Assert.AreEqual(10, imageFrame.Width());
+            Assert.AreEqual(10, imageFrame.Height());
           }
         }
       }
@@ -171,7 +171,7 @@ namespace Tests
     {
       using (var packet = new ImageFramePacket(new ImageFrame()))
       {
-        Assert.AreEqual(packet.DebugTypeName(), "mediapipe::ImageFrame");
+        Assert.AreEqual("mediapipe::ImageFrame", packet.DebugTypeName());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/ImageFramePacketTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class ImageFramePacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class PacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
@@ -17,7 +17,7 @@ namespace Tests
     {
       using (var packet = new BoolPacket())
       {
-        Assert.AreEqual(packet.DebugString(), "mediapipe::Packet with timestamp: Timestamp::Unset() and no data");
+        Assert.AreEqual("mediapipe::Packet with timestamp: Timestamp::Unset() and no data", packet.DebugString());
       }
     }
     #endregion
@@ -28,7 +28,7 @@ namespace Tests
     {
       using (var packet = new BoolPacket())
       {
-        Assert.AreEqual(packet.DebugTypeName(), "{empty}");
+        Assert.AreEqual("{empty}", packet.DebugTypeName());
       }
     }
     #endregion
@@ -39,7 +39,7 @@ namespace Tests
     {
       using (var packet = new BoolPacket())
       {
-        Assert.AreEqual(packet.RegisteredTypeName(), "");
+        Assert.AreEqual("", packet.RegisteredTypeName());
       }
     }
     #endregion
@@ -50,7 +50,7 @@ namespace Tests
     {
       using (var packet = new BoolPacket(true))
       {
-        Assert.AreEqual(packet.ValidateAsProtoMessageLite().Code(), Status.StatusCode.InvalidArgument);
+        Assert.AreEqual(Status.StatusCode.InvalidArgument, packet.ValidateAsProtoMessageLite().Code());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
@@ -17,7 +17,7 @@ namespace Tests
     {
       using (var sidePacket = new SidePacket())
       {
-        Assert.AreEqual(sidePacket.size, 0);
+        Assert.AreEqual(0, sidePacket.size);
       }
     }
 
@@ -31,7 +31,7 @@ namespace Tests
         sidePacket.Emplace("flag", flagPacket);
         sidePacket.Emplace("value", valuePacket);
 
-        Assert.AreEqual(sidePacket.size, 2);
+        Assert.AreEqual(2, sidePacket.size);
         Assert.True(flagPacket.isDisposed);
         Assert.True(valuePacket.isDisposed);
       }
@@ -44,14 +44,14 @@ namespace Tests
     {
       using (var sidePacket = new SidePacket())
       {
-        Assert.AreEqual(sidePacket.size, 0);
+        Assert.AreEqual(0, sidePacket.size);
         Assert.IsNull(sidePacket.At<FloatPacket, float>("value"));
 
         var flagPacket = new FloatPacket(1.0f);
         sidePacket.Emplace("value", flagPacket);
 
-        Assert.AreEqual(sidePacket.size, 1);
-        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
+        Assert.AreEqual(1, sidePacket.size);
+        Assert.AreEqual(1.0f, sidePacket.At<FloatPacket, float>("value").Get());
         Assert.True(flagPacket.isDisposed);
       }
     }
@@ -63,11 +63,11 @@ namespace Tests
       {
         var oldValuePacket = new FloatPacket(1.0f);
         sidePacket.Emplace("value", oldValuePacket);
-        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
+        Assert.AreEqual(1.0f, sidePacket.At<FloatPacket, float>("value").Get());
 
         var newValuePacket = new FloatPacket(2.0f);
         sidePacket.Emplace("value", newValuePacket);
-        Assert.AreEqual(sidePacket.At<FloatPacket, float>("value").Get(), 1.0f);
+        Assert.AreEqual(1.0f, sidePacket.At<FloatPacket, float>("value").Get());
       }
     }
     #endregion
@@ -80,8 +80,8 @@ namespace Tests
       {
         var count = sidePacket.Erase("value");
 
-        Assert.AreEqual(sidePacket.size, 0);
-        Assert.AreEqual(count, 0);
+        Assert.AreEqual(0, sidePacket.size);
+        Assert.AreEqual(0, count);
       }
     }
 
@@ -91,11 +91,11 @@ namespace Tests
       using (var sidePacket = new SidePacket())
       {
         sidePacket.Emplace("value", new BoolPacket(true));
-        Assert.AreEqual(sidePacket.size, 1);
+        Assert.AreEqual(1, sidePacket.size);
 
         var count = sidePacket.Erase("value");
-        Assert.AreEqual(sidePacket.size, 0);
-        Assert.AreEqual(count, 1);
+        Assert.AreEqual(0, sidePacket.size);
+        Assert.AreEqual(1, count);
       }
     }
     #endregion
@@ -108,7 +108,7 @@ namespace Tests
       {
         sidePacket.Clear();
 
-        Assert.AreEqual(sidePacket.size, 0);
+        Assert.AreEqual(0, sidePacket.size);
       }
     }
 
@@ -119,10 +119,10 @@ namespace Tests
       {
         sidePacket.Emplace("flag", new BoolPacket(true));
         sidePacket.Emplace("value", new FloatPacket(1.0f));
-        Assert.AreEqual(sidePacket.size, 2);
+        Assert.AreEqual(2, sidePacket.size);
 
         sidePacket.Clear();
-        Assert.AreEqual(sidePacket.size, 0);
+        Assert.AreEqual(0, sidePacket.size);
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/SidePacketTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class SidePacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System.Text.RegularExpressions;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class StringPacketTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/StringPacketTest.cs
@@ -19,9 +19,9 @@ namespace Tests
       using (var packet = new StringPacket())
       {
 #pragma warning disable IDE0058
-        Assert.AreEqual(packet.ValidateAsType().Code(), Status.StatusCode.Internal);
+        Assert.AreEqual(Status.StatusCode.Internal, packet.ValidateAsType().Code());
         Assert.Throws<MediaPipeException>(() => { packet.Get(); });
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
 #pragma warning restore IDE0058
       }
     }
@@ -32,8 +32,8 @@ namespace Tests
       using (var packet = new StringPacket("test"))
       {
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Get(), "test");
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual("test", packet.Get());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -44,8 +44,8 @@ namespace Tests
       using (var packet = new StringPacket(bytes))
       {
         Assert.True(packet.ValidateAsType().Ok());
-        Assert.AreEqual(packet.Get(), "test");
-        Assert.AreEqual(packet.Timestamp(), Timestamp.Unset());
+        Assert.AreEqual("test", packet.Get());
+        Assert.AreEqual(Timestamp.Unset(), packet.Timestamp());
       }
     }
 
@@ -57,8 +57,8 @@ namespace Tests
         using (var packet = new StringPacket("test", timestamp))
         {
           Assert.True(packet.ValidateAsType().Ok());
-          Assert.AreEqual(packet.Get(), "test");
-          Assert.AreEqual(packet.Timestamp(), timestamp);
+          Assert.AreEqual("test", packet.Get());
+          Assert.AreEqual(timestamp, packet.Timestamp());
         }
       }
     }
@@ -72,8 +72,8 @@ namespace Tests
         using (var packet = new StringPacket(bytes, timestamp))
         {
           Assert.True(packet.ValidateAsType().Ok());
-          Assert.AreEqual(packet.Get(), "test");
-          Assert.AreEqual(packet.Timestamp(), timestamp);
+          Assert.AreEqual("test", packet.Get());
+          Assert.AreEqual(timestamp, packet.Timestamp());
         }
       }
     }
@@ -107,17 +107,17 @@ namespace Tests
       {
         var str = "str";
         var packet = new StringPacket(str).At(timestamp);
-        Assert.AreEqual(packet.Get(), str);
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(str, packet.Get());
+        Assert.AreEqual(timestamp, packet.Timestamp());
 
         using (var newTimestamp = new Timestamp(2))
         {
           var newPacket = packet.At(newTimestamp);
-          Assert.AreEqual(newPacket.Get(), str);
-          Assert.AreEqual(newPacket.Timestamp(), newTimestamp);
+          Assert.AreEqual(str, newPacket.Get());
+          Assert.AreEqual(newTimestamp, newPacket.Timestamp());
         }
 
-        Assert.AreEqual(packet.Timestamp(), timestamp);
+        Assert.AreEqual(timestamp, packet.Timestamp());
       }
     }
     #endregion
@@ -129,8 +129,8 @@ namespace Tests
       var bytes = new byte[] { (byte)'a', (byte)'b', 0, (byte)'c' };
       using (var packet = new StringPacket(bytes))
       {
-        Assert.AreEqual(packet.GetByteArray(), bytes);
-        Assert.AreEqual(packet.Get(), "ab");
+        Assert.AreEqual(bytes, packet.GetByteArray());
+        Assert.AreEqual("ab", packet.Get());
       }
     }
     #endregion
@@ -144,7 +144,7 @@ namespace Tests
         using (var statusOrString = packet.Consume())
         {
           Assert.False(statusOrString.Ok());
-          Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.Internal);
+          Assert.AreEqual(Status.StatusCode.Internal, statusOrString.status.Code());
         }
       }
     }
@@ -157,7 +157,7 @@ namespace Tests
         using (var statusOrString = packet.Consume())
         {
           Assert.True(statusOrString.Ok());
-          Assert.AreEqual(statusOrString.Value(), "abc");
+          Assert.AreEqual("abc", statusOrString.Value());
         }
         Assert.True(packet.IsEmpty());
       }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrGpuResourcesTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrGpuResourcesTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class StatusOrGpuResourcesTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrGpuResourcesTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrGpuResourcesTest.cs
@@ -17,7 +17,7 @@ namespace Tests
     {
       using (var statusOrGpuResources = GpuResources.Create())
       {
-        Assert.AreEqual(statusOrGpuResources.status.Code(), Status.StatusCode.Ok);
+        Assert.AreEqual(Status.StatusCode.Ok, statusOrGpuResources.status.Code());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrImageFrameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrImageFrameTest.cs
@@ -18,7 +18,7 @@ namespace Tests
       using (var statusOrImageFrame = InitializeSubject())
       {
         Assert.True(statusOrImageFrame.Ok());
-        Assert.AreEqual(statusOrImageFrame.status.Code(), Status.StatusCode.Ok);
+        Assert.AreEqual(Status.StatusCode.Ok, statusOrImageFrame.status.Code());
       }
     }
     #endregion
@@ -53,8 +53,8 @@ namespace Tests
 
         using (var imageFrame = statusOrImageFrame.Value())
         {
-          Assert.AreEqual(imageFrame.Width(), 10);
-          Assert.AreEqual(imageFrame.Height(), 10);
+          Assert.AreEqual(10, imageFrame.Width());
+          Assert.AreEqual(10, imageFrame.Height());
           Assert.True(statusOrImageFrame.isDisposed);
         }
       }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrImageFrameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrImageFrameTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class StatusOrImageFrameTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrStringTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrStringTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class StatusOrStringTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrStringTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusOrStringTest.cs
@@ -18,7 +18,7 @@ namespace Tests
       using (var statusOrString = InitializeSubject(""))
       {
         Assert.True(statusOrString.Ok());
-        Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.Ok);
+        Assert.AreEqual(Status.StatusCode.Ok, statusOrString.status.Code());
       }
     }
     #endregion
@@ -51,7 +51,7 @@ namespace Tests
       using (var statusOrString = InitializeSubject(bytes))
       {
         Assert.True(statusOrString.Ok());
-        Assert.AreEqual(statusOrString.Value(), "ab");
+        Assert.AreEqual("ab", statusOrString.Value());
       }
     }
     #endregion
@@ -64,7 +64,7 @@ namespace Tests
       using (var statusOrString = InitializeSubject(bytes))
       {
         Assert.True(statusOrString.Ok());
-        Assert.AreEqual(statusOrString.ValueAsByteArray(), bytes);
+        Assert.AreEqual(bytes, statusOrString.ValueAsByteArray());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class StatusTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Port/StatusTest.cs
@@ -17,7 +17,7 @@ namespace Tests
     {
       using (var status = Status.Ok())
       {
-        Assert.AreEqual(status.Code(), Status.StatusCode.Ok);
+        Assert.AreEqual(Status.StatusCode.Ok, status.Code());
       }
     }
 
@@ -26,7 +26,7 @@ namespace Tests
     {
       using (var status = Status.FailedPrecondition())
       {
-        Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
+        Assert.AreEqual(Status.StatusCode.FailedPrecondition, status.Code());
       }
     }
     #endregion
@@ -57,7 +57,7 @@ namespace Tests
     {
       using (var status = Status.Ok())
       {
-        Assert.AreEqual(status.RawCode(), 0);
+        Assert.AreEqual(0, status.RawCode());
       }
     }
 
@@ -66,7 +66,7 @@ namespace Tests
     {
       using (var status = Status.FailedPrecondition())
       {
-        Assert.AreEqual(status.RawCode(), 9);
+        Assert.AreEqual(9, status.RawCode());
       }
     }
     #endregion
@@ -119,7 +119,7 @@ namespace Tests
     {
       using (var status = Status.Ok())
       {
-        Assert.AreEqual(status.ToString(), "OK");
+        Assert.AreEqual("OK", status.ToString());
       }
     }
 
@@ -129,7 +129,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Cancelled(message))
       {
-        Assert.AreEqual(status.ToString(), $"CANCELLED: {message}");
+        Assert.AreEqual($"CANCELLED: {message}", status.ToString());
       }
     }
 
@@ -139,7 +139,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Unknown(message))
       {
-        Assert.AreEqual(status.ToString(), $"UNKNOWN: {message}");
+        Assert.AreEqual($"UNKNOWN: {message}", status.ToString());
       }
     }
 
@@ -149,7 +149,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.InvalidArgument(message))
       {
-        Assert.AreEqual(status.ToString(), $"INVALID_ARGUMENT: {message}");
+        Assert.AreEqual($"INVALID_ARGUMENT: {message}", status.ToString());
       }
     }
 
@@ -159,7 +159,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.DeadlineExceeded(message))
       {
-        Assert.AreEqual(status.ToString(), $"DEADLINE_EXCEEDED: {message}");
+        Assert.AreEqual($"DEADLINE_EXCEEDED: {message}", status.ToString());
       }
     }
 
@@ -169,7 +169,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.NotFound(message))
       {
-        Assert.AreEqual(status.ToString(), $"NOT_FOUND: {message}");
+        Assert.AreEqual($"NOT_FOUND: {message}", status.ToString());
       }
     }
 
@@ -179,7 +179,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.AlreadyExists(message))
       {
-        Assert.AreEqual(status.ToString(), $"ALREADY_EXISTS: {message}");
+        Assert.AreEqual($"ALREADY_EXISTS: {message}", status.ToString());
       }
     }
 
@@ -189,7 +189,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.PermissionDenied(message))
       {
-        Assert.AreEqual(status.ToString(), $"PERMISSION_DENIED: {message}");
+        Assert.AreEqual($"PERMISSION_DENIED: {message}", status.ToString());
       }
     }
 
@@ -199,7 +199,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.ResourceExhausted(message))
       {
-        Assert.AreEqual(status.ToString(), $"RESOURCE_EXHAUSTED: {message}");
+        Assert.AreEqual($"RESOURCE_EXHAUSTED: {message}", status.ToString());
       }
     }
 
@@ -209,7 +209,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.FailedPrecondition(message))
       {
-        Assert.AreEqual(status.ToString(), $"FAILED_PRECONDITION: {message}");
+        Assert.AreEqual($"FAILED_PRECONDITION: {message}", status.ToString());
       }
     }
 
@@ -219,7 +219,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Aborted(message))
       {
-        Assert.AreEqual(status.ToString(), $"ABORTED: {message}");
+        Assert.AreEqual($"ABORTED: {message}", status.ToString());
       }
     }
 
@@ -229,7 +229,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.OutOfRange(message))
       {
-        Assert.AreEqual(status.ToString(), $"OUT_OF_RANGE: {message}");
+        Assert.AreEqual($"OUT_OF_RANGE: {message}", status.ToString());
       }
     }
 
@@ -239,7 +239,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Unimplemented(message))
       {
-        Assert.AreEqual(status.ToString(), $"UNIMPLEMENTED: {message}");
+        Assert.AreEqual($"UNIMPLEMENTED: {message}", status.ToString());
       }
     }
 
@@ -249,7 +249,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Internal(message))
       {
-        Assert.AreEqual(status.ToString(), $"INTERNAL: {message}");
+        Assert.AreEqual($"INTERNAL: {message}", status.ToString());
       }
     }
 
@@ -259,7 +259,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Unavailable(message))
       {
-        Assert.AreEqual(status.ToString(), $"UNAVAILABLE: {message}");
+        Assert.AreEqual($"UNAVAILABLE: {message}", status.ToString());
       }
     }
 
@@ -269,7 +269,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.DataLoss(message))
       {
-        Assert.AreEqual(status.ToString(), $"DATA_LOSS: {message}");
+        Assert.AreEqual($"DATA_LOSS: {message}", status.ToString());
       }
     }
 
@@ -279,7 +279,7 @@ namespace Tests
       var message = "Some error";
       using (var status = Status.Unauthenticated(message))
       {
-        Assert.AreEqual(status.ToString(), $"UNAUTHENTICATED: {message}");
+        Assert.AreEqual($"UNAUTHENTICATED: {message}", status.ToString());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/TimestampTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/TimestampTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class TimestampTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/TimestampTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/TimestampTest.cs
@@ -37,7 +37,7 @@ namespace Tests
     {
       using (var timestamp = new Timestamp(10))
       {
-        Assert.AreEqual(timestamp.Value(), 10);
+        Assert.AreEqual(10, timestamp.Value());
       }
     }
     #endregion
@@ -48,7 +48,7 @@ namespace Tests
     {
       using (var timestamp = new Timestamp(1_000_000))
       {
-        Assert.AreEqual(timestamp.Seconds(), 1d, 1e-9);
+        Assert.AreEqual(1d, timestamp.Seconds(), 1e-9);
       }
     }
     #endregion
@@ -59,7 +59,7 @@ namespace Tests
     {
       using (var timestamp = new Timestamp(1_000_000))
       {
-        Assert.AreEqual(timestamp.Microseconds(), 1_000_000);
+        Assert.AreEqual(1_000_000, timestamp.Microseconds());
       }
     }
     #endregion
@@ -175,7 +175,7 @@ namespace Tests
     {
       using (var timestamp = new Timestamp(1))
       {
-        Assert.AreEqual(timestamp.DebugString(), "1");
+        Assert.AreEqual("1", timestamp.DebugString());
       }
     }
 
@@ -184,7 +184,7 @@ namespace Tests
     {
       using (var timestamp = Timestamp.Unset())
       {
-        Assert.AreEqual(timestamp.DebugString(), "Timestamp::Unset()");
+        Assert.AreEqual("Timestamp::Unset()", timestamp.DebugString());
       }
     }
     #endregion
@@ -197,7 +197,7 @@ namespace Tests
       {
         using (var nextTimestamp = timestamp.NextAllowedInStream())
         {
-          Assert.AreEqual(nextTimestamp.Microseconds(), 2);
+          Assert.AreEqual(2, nextTimestamp.Microseconds());
         }
       }
     }
@@ -209,7 +209,7 @@ namespace Tests
       {
         using (var nextTimestamp = timestamp.NextAllowedInStream())
         {
-          Assert.AreEqual(nextTimestamp, Timestamp.OneOverPostStream());
+          Assert.AreEqual(Timestamp.OneOverPostStream(), nextTimestamp);
         }
       }
     }
@@ -223,7 +223,7 @@ namespace Tests
       {
         using (var nextTimestamp = timestamp.PreviousAllowedInStream())
         {
-          Assert.AreEqual(nextTimestamp.Microseconds(), 0);
+          Assert.AreEqual(0, nextTimestamp.Microseconds());
         }
       }
     }
@@ -235,7 +235,7 @@ namespace Tests
       {
         using (var nextTimestamp = timestamp.PreviousAllowedInStream())
         {
-          Assert.AreEqual(nextTimestamp, Timestamp.Unstarted());
+          Assert.AreEqual(Timestamp.Unstarted(), nextTimestamp);
         }
       }
     }
@@ -247,7 +247,7 @@ namespace Tests
     {
       using (var timestamp = Timestamp.FromSeconds(1d))
       {
-        Assert.AreEqual(timestamp.Microseconds(), 1_000_000);
+        Assert.AreEqual(1_000_000, timestamp.Microseconds());
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/NameUtilTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/NameUtilTest.cs
@@ -19,7 +19,7 @@ namespace Tests
     public void GetUnusedNodeName_ShouldReturnUniqueName(string configJson, string nameBase, string uniqueName)
     {
       var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
-      Assert.AreEqual(Tool.GetUnusedNodeName(config, nameBase), uniqueName);
+      Assert.AreEqual(uniqueName, Tool.GetUnusedNodeName(config, nameBase));
     }
 
     [TestCase("{}", "base", "base")]
@@ -29,7 +29,7 @@ namespace Tests
     public void GetUnusedSidePacketName_ShouldReturnUniqueName(string configJson, string nameBase, string uniqueName)
     {
       var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
-      Assert.AreEqual(Tool.GetUnusedSidePacketName(config, nameBase), uniqueName);
+      Assert.AreEqual(uniqueName, Tool.GetUnusedSidePacketName(config, nameBase));
     }
 
     [TestCase(@"{""node"":[{""name"":""x""}]}", 0, "x")]
@@ -44,7 +44,7 @@ namespace Tests
     public void CanonicalNodeName_ShouldReturnCanonicalNodeName_When_NodeIdIsValid(string configJson, int nodeId, string name)
     {
       var config = CalculatorGraphConfig.Parser.ParseJson(configJson);
-      Assert.AreEqual(Tool.CanonicalNodeName(config, nodeId), name);
+      Assert.AreEqual(name, Tool.CanonicalNodeName(config, nodeId));
     }
 
     [Test]
@@ -79,7 +79,7 @@ namespace Tests
     [TestCase("TAG:1:x", "x")]
     public void ParseNameFromStream_ShouldReturnName_When_InputIsValid(string stream, string name)
     {
-      Assert.AreEqual(Tool.ParseNameFromStream(stream), name);
+      Assert.AreEqual(name, Tool.ParseNameFromStream(stream));
     }
 
     [TestCase(":stream")]
@@ -100,8 +100,8 @@ namespace Tests
     {
       var output = Tool.ParseTagIndex(tagIndex);
 
-      Assert.AreEqual(output.Item1, tag);
-      Assert.AreEqual(output.Item2, index);
+      Assert.AreEqual(tag, output.Item1);
+      Assert.AreEqual(index, output.Item2);
     }
 
     [TestCase("tag")]
@@ -122,8 +122,8 @@ namespace Tests
     {
       var output = Tool.ParseTagIndexFromStream(stream);
 
-      Assert.AreEqual(output.Item1, tag);
-      Assert.AreEqual(output.Item2, index);
+      Assert.AreEqual(tag, output.Item1);
+      Assert.AreEqual(index, output.Item2);
     }
 
     [TestCase(":stream")]
@@ -142,7 +142,7 @@ namespace Tests
     [TestCase("TAG", 1, "TAG:1")]
     public void CatTag_ShouldReturnTag(string tag, int index, string output)
     {
-      Assert.AreEqual(Tool.CatTag(tag, index), output);
+      Assert.AreEqual(output, Tool.CatTag(tag, index));
     }
 
     [TestCase("", -1, "x", "x")]
@@ -151,7 +151,7 @@ namespace Tests
     [TestCase("TAG", 1, "x", "TAG:1:x")]
     public void CatStream_ShouldReturnStream(string tag, int index, string name, string output)
     {
-      Assert.AreEqual(Tool.CatStream((tag, index), name), output);
+      Assert.AreEqual(output, Tool.CatStream((tag, index), name));
     }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/NameUtilTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/NameUtilTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class NameUtilTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/ValidateNameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/ValidateNameTest.cs
@@ -114,8 +114,8 @@ namespace Tests
     {
       Tool.ParseTagAndName(input, out var tag, out var name);
 
-      Assert.AreEqual(tag, expectedTag);
-      Assert.AreEqual(name, expectedName);
+      Assert.AreEqual(expectedTag, tag);
+      Assert.AreEqual(expectedName, name);
     }
 
     [TestCase(":humphrey")]
@@ -130,8 +130,8 @@ namespace Tests
 
 #pragma warning disable IDE0058
       Assert.Throws<ArgumentException>(() => { Tool.ParseTagAndName(input, out tag, out name); });
-      Assert.AreEqual(tag, "UNTOUCHED");
-      Assert.AreEqual(name, "untouched");
+      Assert.AreEqual("UNTOUCHED", tag);
+      Assert.AreEqual("untouched", name);
 #pragma warning restore IDE0058
     }
 
@@ -158,9 +158,9 @@ namespace Tests
     {
       Tool.ParseTagIndexName(input, out var tag, out var index, out var name);
 
-      Assert.AreEqual(tag, expectedTag);
-      Assert.AreEqual(index, expectedIndex);
-      Assert.AreEqual(name, expectedName);
+      Assert.AreEqual(expectedTag, tag);
+      Assert.AreEqual(expectedIndex, index);
+      Assert.AreEqual(expectedName, name);
     }
 
     [TestCase("")]
@@ -207,9 +207,9 @@ namespace Tests
 
 #pragma warning disable IDE0058
       Assert.Throws<ArgumentException>(() => { Tool.ParseTagIndexName(input, out tag, out index, out name); });
-      Assert.AreEqual(tag, "UNTOUCHED");
-      Assert.AreEqual(index, -1);
-      Assert.AreEqual(name, "untouched");
+      Assert.AreEqual("UNTOUCHED", tag);
+      Assert.AreEqual(-1, index);
+      Assert.AreEqual("untouched", name);
 #pragma warning restore IDE0058
     }
 
@@ -237,8 +237,8 @@ namespace Tests
     {
       Tool.ParseTagIndex(input, out var tag, out var index);
 
-      Assert.AreEqual(tag, expectedTag);
-      Assert.AreEqual(index, expectedIndex);
+      Assert.AreEqual(expectedTag, tag);
+      Assert.AreEqual(expectedIndex, index);
     }
 
     [TestCase("a")]
@@ -272,8 +272,8 @@ namespace Tests
 
 #pragma warning disable IDE0058
       Assert.Throws<ArgumentException>(() => { Tool.ParseTagIndex(input, out tag, out index); });
-      Assert.AreEqual(tag, "UNTOUCHED");
-      Assert.AreEqual(index, -1);
+      Assert.AreEqual("UNTOUCHED", tag);
+      Assert.AreEqual(-1, index);
 #pragma warning restore IDE0058
     }
 

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/ValidateNameTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Tool/ValidateNameTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class ValidateNameTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/ValidatedGraphConfigTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/ValidatedGraphConfigTest.cs
@@ -4,12 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
-using Mediapipe.Unity;
 using NUnit.Framework;
 using System.Linq;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class ValidatedGraphConfigTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/ValidatedGraphConfigTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/ValidatedGraphConfigTest.cs
@@ -139,7 +139,7 @@ node {
       {
         using (var status = config.Initialize("InvalidSubgraph"))
         {
-          Assert.AreEqual(status.Code(), Status.StatusCode.NotFound);
+          Assert.AreEqual(Status.StatusCode.NotFound, status.Code());
         }
         Assert.False(config.Initialized());
       }
@@ -206,7 +206,7 @@ node {
         {
           using (var status = config.ValidateRequiredSidePackets(sidePacket))
           {
-            Assert.AreEqual(status.Code(), Status.StatusCode.InvalidArgument);
+            Assert.AreEqual(Status.StatusCode.InvalidArgument, status.Code());
           }
         }
       }
@@ -223,7 +223,7 @@ node {
           sidePacket.Emplace("max_num_objects", new IntPacket(3));
           using (var status = config.ValidateRequiredSidePackets(sidePacket))
           {
-            Assert.AreEqual(status.Code(), Status.StatusCode.InvalidArgument);
+            Assert.AreEqual(Status.StatusCode.InvalidArgument, status.Code());
           }
         }
       }
@@ -241,7 +241,7 @@ node {
           sidePacket.Emplace("max_num_objects", new StringPacket("3"));
           using (var status = config.ValidateRequiredSidePackets(sidePacket))
           {
-            Assert.AreEqual(status.Code(), Status.StatusCode.InvalidArgument);
+            Assert.AreEqual(Status.StatusCode.InvalidArgument, status.Code());
           }
         }
       }
@@ -290,11 +290,11 @@ node {
         Assert.AreEqual(originalConfig.InputStream, canonicalizedConfig.InputStream);
         Assert.AreEqual(originalConfig.OutputStream, canonicalizedConfig.OutputStream);
         Assert.IsEmpty(originalConfig.Executor);
-        Assert.AreEqual(canonicalizedConfig.Executor.Count, 1);
-        Assert.AreEqual(canonicalizedConfig.Executor[0].CalculateSize(), 0);
+        Assert.AreEqual(1, canonicalizedConfig.Executor.Count);
+        Assert.AreEqual(0, canonicalizedConfig.Executor[0].CalculateSize());
 
-        Assert.AreEqual(originalConfig.CalculateSize(), 80);
-        Assert.AreEqual(canonicalizedConfig.CalculateSize(), 82);
+        Assert.AreEqual(80, originalConfig.CalculateSize());
+        Assert.AreEqual(82, canonicalizedConfig.CalculateSize());
       }
     }
 
@@ -307,8 +307,8 @@ node {
         config.Initialize(originalConfig).AssertOk();
         var canonicalizedConfig = config.Config();
 
-        Assert.AreEqual(originalConfig.CalculateSize(), 251);
-        Assert.AreEqual(canonicalizedConfig.CalculateSize(), 26514);
+        Assert.AreEqual(251, originalConfig.CalculateSize());
+        Assert.AreEqual(26514, canonicalizedConfig.CalculateSize());
       }
     }
     #endregion
@@ -344,15 +344,15 @@ node {
         Assert.AreEqual(inputStreamInfos.Count, 2);
 
         var inStream = inputStreamInfos.First((edgeInfo) => edgeInfo.name == "in");
-        Assert.AreEqual(inStream.upstream, 0);
-        Assert.AreEqual(inStream.parentNode.type, NodeType.Calculator);
-        Assert.AreEqual(inStream.parentNode.index, 0);
+        Assert.AreEqual(0, inStream.upstream);
+        Assert.AreEqual(NodeType.Calculator, inStream.parentNode.type);
+        Assert.AreEqual(0, inStream.parentNode.index);
         Assert.False(inStream.backEdge);
 
         var out1Stream = inputStreamInfos.First((edgeInfo) => edgeInfo.name == "out1");
-        Assert.AreEqual(out1Stream.upstream, 1);
-        Assert.AreEqual(out1Stream.parentNode.type, NodeType.Calculator);
-        Assert.AreEqual(out1Stream.parentNode.index, 1);
+        Assert.AreEqual(1, out1Stream.upstream);
+        Assert.AreEqual(NodeType.Calculator, out1Stream.parentNode.type);
+        Assert.AreEqual(1, out1Stream.parentNode.index);
         Assert.False(out1Stream.backEdge);
       }
     }
@@ -376,24 +376,24 @@ node {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
         var outputStreamInfos = config.OutputStreamInfos();
 
-        Assert.AreEqual(outputStreamInfos.Count, 3);
+        Assert.AreEqual(3, outputStreamInfos.Count);
 
         var inStream = outputStreamInfos.First((edgeInfo) => edgeInfo.name == "in");
-        Assert.AreEqual(inStream.upstream, -1);
-        Assert.AreEqual(inStream.parentNode.type, NodeType.GraphInputStream);
-        Assert.AreEqual(inStream.parentNode.index, 2);
+        Assert.AreEqual(-1, inStream.upstream);
+        Assert.AreEqual(NodeType.GraphInputStream, inStream.parentNode.type);
+        Assert.AreEqual(2, inStream.parentNode.index, 2);
         Assert.False(inStream.backEdge);
 
         var out1Stream = outputStreamInfos.First((edgeInfo) => edgeInfo.name == "out1");
-        Assert.AreEqual(out1Stream.upstream, -1);
-        Assert.AreEqual(out1Stream.parentNode.type, NodeType.Calculator);
-        Assert.AreEqual(out1Stream.parentNode.index, 0);
+        Assert.AreEqual(-1, out1Stream.upstream);
+        Assert.AreEqual(NodeType.Calculator, out1Stream.parentNode.type);
+        Assert.AreEqual(0, out1Stream.parentNode.index);
         Assert.False(out1Stream.backEdge);
 
         var outStream = outputStreamInfos.First((edgeInfo) => edgeInfo.name == "out");
-        Assert.AreEqual(outStream.upstream, -1);
-        Assert.AreEqual(outStream.parentNode.type, NodeType.Calculator);
-        Assert.AreEqual(outStream.parentNode.index, 1);
+        Assert.AreEqual(-1, outStream.upstream);
+        Assert.AreEqual(NodeType.Calculator, outStream.parentNode.type);
+        Assert.AreEqual(1, outStream.parentNode.index);
         Assert.False(outStream.backEdge);
       }
     }
@@ -430,13 +430,13 @@ node {
         Assert.True(inputSidePacketInfos.Count >= 2);
 
         var modelComplexityPacket = inputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "model_complexity");
-        Assert.AreEqual(modelComplexityPacket.upstream, -1);
-        Assert.AreEqual(modelComplexityPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, modelComplexityPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, modelComplexityPacket.parentNode.type);
         Assert.False(modelComplexityPacket.backEdge);
 
         var smoothLandmarksPacket = inputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "smooth_landmarks");
-        Assert.AreEqual(smoothLandmarksPacket.upstream, -1);
-        Assert.AreEqual(smoothLandmarksPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, smoothLandmarksPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, smoothLandmarksPacket.parentNode.type);
         Assert.False(smoothLandmarksPacket.backEdge);
       }
     }
@@ -470,26 +470,26 @@ node {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_ConstantSidePacketConfigText)).AssertOk();
         var outputSidePacketInfos = config.OutputSidePacketInfos();
 
-        Assert.AreEqual(outputSidePacketInfos.Count, 4);
+        Assert.AreEqual(4, outputSidePacketInfos.Count);
 
         var intPacket = outputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "int_packet");
-        Assert.AreEqual(intPacket.upstream, -1);
-        Assert.AreEqual(intPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, intPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, intPacket.parentNode.type);
         Assert.False(intPacket.backEdge);
 
         var floatPacket = outputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "float_packet");
-        Assert.AreEqual(floatPacket.upstream, -1);
-        Assert.AreEqual(floatPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, floatPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, floatPacket.parentNode.type);
         Assert.False(floatPacket.backEdge);
 
         var boolPacket = outputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "bool_packet");
-        Assert.AreEqual(boolPacket.upstream, -1);
-        Assert.AreEqual(boolPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, boolPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, boolPacket.parentNode.type);
         Assert.False(boolPacket.backEdge);
 
         var stringPacket = outputSidePacketInfos.First((edgeInfo) => edgeInfo.name == "string_packet");
-        Assert.AreEqual(stringPacket.upstream, -1);
-        Assert.AreEqual(stringPacket.parentNode.type, NodeType.Calculator);
+        Assert.AreEqual(-1, stringPacket.upstream);
+        Assert.AreEqual(NodeType.Calculator, stringPacket.parentNode.type);
         Assert.False(stringPacket.backEdge);
       }
     }
@@ -501,7 +501,7 @@ node {
     {
       using (var config = new ValidatedGraphConfig())
       {
-        Assert.AreEqual(config.OutputStreamIndex(""), -1);
+        Assert.AreEqual(-1, config.OutputStreamIndex(""));
       }
     }
 
@@ -511,7 +511,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputStreamIndex("unknown"), -1);
+        Assert.AreEqual(-1, config.OutputStreamIndex("unknown"));
       }
     }
 
@@ -521,7 +521,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputStreamIndex("out"), 2);
+        Assert.AreEqual(2, config.OutputStreamIndex("out"));
       }
     }
 
@@ -531,7 +531,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputStreamIndex("out1"), 1);
+        Assert.AreEqual(1, config.OutputStreamIndex("out1"));
       }
     }
     #endregion
@@ -542,7 +542,7 @@ node {
     {
       using (var config = new ValidatedGraphConfig())
       {
-        Assert.AreEqual(config.OutputSidePacketIndex(""), -1);
+        Assert.AreEqual(-1, config.OutputSidePacketIndex(""));
       }
     }
 
@@ -552,7 +552,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_ConstantSidePacketConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputSidePacketIndex("unknown"), -1);
+        Assert.AreEqual(-1, config.OutputSidePacketIndex("unknown"));
       }
     }
 
@@ -562,7 +562,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_ConstantSidePacketConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputSidePacketIndex("int_packet"), 0);
+        Assert.AreEqual(0, config.OutputSidePacketIndex("int_packet"));
       }
     }
     #endregion
@@ -574,7 +574,7 @@ node {
     {
       using (var config = new ValidatedGraphConfig())
       {
-        Assert.AreEqual(config.OutputStreamToNode(""), -1);
+        Assert.AreEqual(-1, config.OutputStreamToNode(""));
       }
     }
 
@@ -584,7 +584,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputStreamToNode("unknown"), -1);
+        Assert.AreEqual(-1, config.OutputStreamToNode("unknown"));
       }
     }
 
@@ -594,7 +594,7 @@ node {
       using (var config = new ValidatedGraphConfig())
       {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
-        Assert.AreEqual(config.OutputStreamToNode("out1"), 0);
+        Assert.AreEqual(0, config.OutputStreamToNode("out1"));
       }
     }
     #endregion
@@ -607,7 +607,7 @@ node {
       {
         using (var statusOrString = config.RegisteredSidePacketTypeName("model_complexity"))
         {
-          Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.InvalidArgument);
+          Assert.AreEqual(Status.StatusCode.InvalidArgument, statusOrString.status.Code());
         }
       }
     }
@@ -620,7 +620,7 @@ node {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PoseLandmarkConfigText)).AssertOk();
         using (var statusOrString = config.RegisteredSidePacketTypeName("model_complexity"))
         {
-          Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.Unknown);
+          Assert.AreEqual(Status.StatusCode.Unknown, statusOrString.status.Code());
         }
       }
     }
@@ -634,7 +634,7 @@ node {
       {
         using (var statusOrString = config.RegisteredStreamTypeName("in"))
         {
-          Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.InvalidArgument);
+          Assert.AreEqual(Status.StatusCode.InvalidArgument, statusOrString.status.Code());
         }
       }
     }
@@ -647,7 +647,7 @@ node {
         config.Initialize(CalculatorGraphConfig.Parser.ParseFromTextFormat(_PassThroughConfigText)).AssertOk();
         using (var statusOrString = config.RegisteredStreamTypeName("in"))
         {
-          Assert.AreEqual(statusOrString.status.Code(), Status.StatusCode.Unknown);
+          Assert.AreEqual(Status.StatusCode.Unknown, statusOrString.status.Code());
         }
       }
     }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class GlCalculatorHelperTest
   {
@@ -109,7 +108,7 @@ namespace Tests
     }
 
     [Test, GpuOnly]
-    [Ignore("Skip because a thread hangs")]
+    [Ignore("Skip because a thread will hang")]
     public void CreateSourceTexture_ShouldFail_When_ImageFrameFormatIsInvalid()
     {
       using (var glCalculatorHelper = new GlCalculatorHelper())

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
@@ -18,7 +18,7 @@ namespace Tests
     {
       using (var glCalculatorHelper = new GlCalculatorHelper())
       {
-        Assert.AreNotEqual(glCalculatorHelper.mpPtr, IntPtr.Zero);
+        Assert.AreNotEqual(IntPtr.Zero, glCalculatorHelper.mpPtr);
       }
     }
     #endregion
@@ -77,7 +77,7 @@ namespace Tests
         glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
         var status = glCalculatorHelper.RunInGlContext((GlCalculatorHelper.GlFunction)(() => { throw new Exception("Function Throws"); }));
-        Assert.AreEqual(status.Code(), Status.StatusCode.Internal);
+        Assert.AreEqual(Status.StatusCode.Internal, status.Code());
       }
     }
     #endregion
@@ -96,8 +96,8 @@ namespace Tests
           {
             var texture = glCalculatorHelper.CreateSourceTexture(imageFrame);
 
-            Assert.AreEqual(texture.width, 32);
-            Assert.AreEqual(texture.height, 24);
+            Assert.AreEqual(32, texture.width);
+            Assert.AreEqual(24, texture.height);
 
             texture.Dispose();
           });
@@ -125,7 +125,7 @@ namespace Tests
               texture.Release();
             }
           });
-          Assert.AreEqual(status.Code(), Status.StatusCode.FailedPrecondition);
+          Assert.AreEqual(Status.StatusCode.FailedPrecondition, status.Code());
 
           status.Dispose();
         }
@@ -145,8 +145,8 @@ namespace Tests
         {
           var glTexture = glCalculatorHelper.CreateDestinationTexture(32, 24, GpuBufferFormat.kBGRA32);
 
-          Assert.AreEqual(glTexture.width, 32);
-          Assert.AreEqual(glTexture.height, 24);
+          Assert.AreEqual(32, glTexture.width);
+          Assert.AreEqual(24, glTexture.height);
         });
 
         Assert.True(status.Ok());
@@ -163,7 +163,7 @@ namespace Tests
         glCalculatorHelper.InitializeForTest(GpuResources.Create().Value());
 
         // default frame buffer
-        Assert.AreEqual(glCalculatorHelper.framebuffer, 0);
+        Assert.AreEqual(0, glCalculatorHelper.framebuffer);
       }
     }
     #endregion
@@ -179,11 +179,11 @@ namespace Tests
         using (var glContext = glCalculatorHelper.GetGlContext())
         {
 #if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_ANDROID
-          Assert.AreNotEqual(glContext.eglContext, IntPtr.Zero);
+          Assert.AreNotEqual(IntPtr.Zero, glContext.eglContext);
 #elif UNITY_STANDALONE_OSX
-          Assert.AreNotEqual(glContext.nsglContext, IntPtr.Zero);
+          Assert.AreNotEqual(IntPtr.Zero, glContext.nsglContext);
 #elif UNITY_IOS
-          Assert.AreNotEqual(glContext.eaglContext, IntPtr.Zero);
+          Assert.AreNotEqual(IntPtr.Zero, glContext.eaglContext);
 #endif
         }
       }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
@@ -4,11 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 using System;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class GlContextTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
@@ -56,16 +56,16 @@ namespace Tests
       using (var glContext = GetGlContext())
       {
 #if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_ANDROID
-        Assert.AreNotEqual(glContext.eglDisplay, IntPtr.Zero);
-        Assert.AreNotEqual(glContext.eglConfig, IntPtr.Zero);
-        Assert.AreNotEqual(glContext.eglContext, IntPtr.Zero);
-        Assert.AreEqual(glContext.glMajorVersion, 3);
-        Assert.AreEqual(glContext.glMinorVersion, 2);
-        Assert.AreEqual(glContext.glFinishCount, 0);
+        Assert.AreNotEqual(IntPtr.Zero, glContext.eglDisplay);
+        Assert.AreNotEqual(IntPtr.Zero, glContext.eglConfig);
+        Assert.AreNotEqual(IntPtr.Zero, glContext.eglContext);
+        Assert.AreEqual(3, glContext.glMajorVersion);
+        Assert.AreEqual(2, glContext.glMinorVersion);
+        Assert.AreEqual(0, glContext.glFinishCount);
 #elif UNITY_STANDALONE_OSX
-        Assert.AreNotEqual(glContext.nsglContext, IntPtr.Zero);
+        Assert.AreNotEqual(IntPtr.Zero, glContext.nsglContext);
 #elif UNITY_IOS
-        Assert.AreNotEqual(glContext.eaglContext, IntPtr.Zero);
+        Assert.AreNotEqual(IntPtr.Zero, glContext.eaglContext);
 #endif
       }
     }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class GlTextureTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
@@ -17,8 +17,8 @@ namespace Tests
     {
       using (var glTexture = new GlTexture())
       {
-        Assert.AreEqual(glTexture.width, 0);
-        Assert.AreEqual(glTexture.height, 0);
+        Assert.AreEqual(0, glTexture.width);
+        Assert.AreEqual(0, glTexture.height);
       }
     }
     #endregion
@@ -49,7 +49,7 @@ namespace Tests
     {
       using (var glTexture = new GlTexture())
       {
-        Assert.AreEqual(glTexture.target, Gl.GL_TEXTURE_2D);
+        Assert.AreEqual(Gl.GL_TEXTURE_2D, glTexture.target);
       }
     }
     #endregion

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GpuResourcesTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GpuResourcesTest.cs
@@ -4,10 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
 using NUnit.Framework;
 
-namespace Tests
+namespace Mediapipe.Tests
 {
   public class GpuResourcesTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/GpuOnlyAttribute.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/GpuOnlyAttribute.cs
@@ -7,5 +7,8 @@
 using NUnit.Framework;
 using System;
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public class GpuOnlyAttribute : CategoryAttribute { }
+namespace Mediapipe
+{
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+  public class GpuOnlyAttribute : CategoryAttribute { }
+}

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/SignalAbortAttribute.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/SignalAbortAttribute.cs
@@ -7,5 +7,8 @@
 using NUnit.Framework;
 using System;
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public class SignalAbortAttribute : CategoryAttribute { }
+namespace Mediapipe
+{
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+  public class SignalAbortAttribute : CategoryAttribute { }
+}

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/CoordinateSystem/ImageCoordinateTest.cs
@@ -4,12 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe.Unity;
-using Mediapipe.Unity.CoordinateSystem;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Tests
+namespace Mediapipe.Unity.CoordinateSystem.Tests
 {
   public class ImageCoordinateTest
   {
@@ -401,11 +399,11 @@ namespace Tests
     }
     #endregion
 
-    private Rect BuildRect(float xMin, float xMax, float yMin, float yMax)
+    private UnityEngine.Rect BuildRect(float xMin, float xMax, float yMin, float yMax)
     {
       var x = xMax < 0 ? xMin : -xMax;
       var y = yMax < 0 ? yMin : -yMax;
-      var rect = new Rect(x, y, -2 * x, -2 * y);
+      var rect = new UnityEngine.Rect(x, y, -2 * x, -2 * y);
 
       if (xMax < 0)
       {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/Extension/ImageFrameExtensionTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/Extension/ImageFrameExtensionTest.cs
@@ -4,16 +4,13 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using Mediapipe;
-using Mediapipe.Unity;
-
 using NUnit.Framework;
 using Unity.Collections;
 using UnityEngine;
 
 using System.Linq;
 
-namespace Tests
+namespace Mediapipe.Unity.Tests
 {
   public class ImageFrameExtensionTest
   {

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/Extension/ImageFrameExtensionTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Unity/Extension/ImageFrameExtensionTest.cs
@@ -128,40 +128,40 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgb, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new byte[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new byte[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new byte[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new byte[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new byte[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new byte[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new byte[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new byte[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new byte[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new byte[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new byte[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new byte[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new byte[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new byte[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new byte[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new byte[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new byte[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new byte[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new byte[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new byte[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new byte[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new byte[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new byte[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new byte[] { 67, 35, 3, 75, 43, 11 }, result);
 
       }
     }
@@ -180,52 +180,52 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new byte[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new byte[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new byte[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new byte[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new byte[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new byte[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new byte[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new byte[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new byte[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new byte[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new byte[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new byte[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new byte[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new byte[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new byte[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new byte[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new byte[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new byte[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new byte[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new byte[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new byte[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new byte[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new byte[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new byte[] { 67, 35, 3, 75, 43, 11 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, false));
-        Assert.AreEqual(result, new byte[] { 12, 44, 76, 4, 36, 68 });
+        Assert.AreEqual(new byte[] { 12, 44, 76, 4, 36, 68 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, true));
-        Assert.AreEqual(result, new byte[] { 4, 36, 68, 12, 44, 76 });
+        Assert.AreEqual(new byte[] { 4, 36, 68, 12, 44, 76 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, false));
-        Assert.AreEqual(result, new byte[] { 76, 44, 12, 68, 36, 4 });
+        Assert.AreEqual(new byte[] { 76, 44, 12, 68, 36, 4 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, true));
-        Assert.AreEqual(result, new byte[] { 68, 36, 4, 76, 44, 12 });
+        Assert.AreEqual(new byte[] { 68, 36, 4, 76, 44, 12 }, result);
       }
     }
 
@@ -243,52 +243,52 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Sbgra, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new byte[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new byte[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new byte[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new byte[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new byte[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new byte[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new byte[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new byte[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new byte[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new byte[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new byte[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new byte[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new byte[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new byte[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new byte[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new byte[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new byte[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new byte[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new byte[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new byte[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new byte[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new byte[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new byte[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new byte[] { 67, 35, 3, 75, 43, 11 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, false));
-        Assert.AreEqual(result, new byte[] { 12, 44, 76, 4, 36, 68 });
+        Assert.AreEqual(new byte[] { 12, 44, 76, 4, 36, 68 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, true));
-        Assert.AreEqual(result, new byte[] { 4, 36, 68, 12, 44, 76 });
+        Assert.AreEqual(new byte[] { 4, 36, 68, 12, 44, 76 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, false));
-        Assert.AreEqual(result, new byte[] { 76, 44, 12, 68, 36, 4 });
+        Assert.AreEqual(new byte[] { 76, 44, 12, 68, 36, 4 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, true));
-        Assert.AreEqual(result, new byte[] { 68, 36, 4, 76, 44, 12 });
+        Assert.AreEqual(new byte[] { 68, 36, 4, 76, 44, 12 }, result);
       }
     }
 
@@ -305,16 +305,16 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray8, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new byte[] { 4, 5, 6, 1, 2, 3 });
+        Assert.AreEqual(new byte[] { 4, 5, 6, 1, 2, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new byte[] { 1, 2, 3, 4, 5, 6 });
+        Assert.AreEqual(new byte[] { 1, 2, 3, 4, 5, 6 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new byte[] { 6, 5, 4, 3, 2, 1 });
+        Assert.AreEqual(new byte[] { 6, 5, 4, 3, 2, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new byte[] { 3, 2, 1, 6, 5, 4 });
+        Assert.AreEqual(new byte[] { 3, 2, 1, 6, 5, 4 }, result);
       }
     }
 
@@ -332,40 +332,40 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Lab8, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new byte[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new byte[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new byte[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new byte[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new byte[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new byte[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new byte[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new byte[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new byte[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new byte[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new byte[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new byte[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new byte[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new byte[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new byte[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new byte[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new byte[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new byte[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new byte[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new byte[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new byte[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new byte[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new byte[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new byte[] { 67, 35, 3, 75, 43, 11 }, result);
       }
     }
     #endregion
@@ -471,40 +471,40 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgb48, 3, 2, 24, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new ushort[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new ushort[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new ushort[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new ushort[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new ushort[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new ushort[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new ushort[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new ushort[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new ushort[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new ushort[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new ushort[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new ushort[] { 67, 35, 3, 75, 43, 11 }, result);
       }
     }
 
@@ -522,52 +522,52 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba64, 3, 2, 24, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 9, 41, 73, 1, 33, 65 });
+        Assert.AreEqual(new ushort[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 1, 33, 65, 9, 41, 73 });
+        Assert.AreEqual(new ushort[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 73, 41, 9, 65, 33, 1 });
+        Assert.AreEqual(new ushort[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 65, 33, 1, 73, 41, 9 });
+        Assert.AreEqual(new ushort[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 10, 42, 74, 2, 34, 66 });
+        Assert.AreEqual(new ushort[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 2, 34, 66, 10, 42, 74 });
+        Assert.AreEqual(new ushort[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 74, 42, 10, 66, 34, 2 });
+        Assert.AreEqual(new ushort[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 66, 34, 2, 74, 42, 10 });
+        Assert.AreEqual(new ushort[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 11, 43, 75, 3, 35, 67 });
+        Assert.AreEqual(new ushort[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 3, 35, 67, 11, 43, 75 });
+        Assert.AreEqual(new ushort[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 75, 43, 11, 67, 35, 3 });
+        Assert.AreEqual(new ushort[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(2, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 67, 35, 3, 75, 43, 11 });
+        Assert.AreEqual(new ushort[] { 67, 35, 3, 75, 43, 11 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 12, 44, 76, 4, 36, 68 });
+        Assert.AreEqual(new ushort[] { 12, 44, 76, 4, 36, 68 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 4, 36, 68, 12, 44, 76 });
+        Assert.AreEqual(new ushort[] { 4, 36, 68, 12, 44, 76 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 76, 44, 12, 68, 36, 4 });
+        Assert.AreEqual(new ushort[] { 76, 44, 12, 68, 36, 4 }, result);
 
         Assert.True(imageFrame.TryReadChannel(3, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 68, 36, 4, 76, 44, 12 });
+        Assert.AreEqual(new ushort[] { 68, 36, 4, 76, 44, 12 }, result);
       }
     }
 
@@ -584,16 +584,16 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray16, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new ushort[] { 4, 5, 6, 1, 2, 3 });
+        Assert.AreEqual(new ushort[] { 4, 5, 6, 1, 2, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new ushort[] { 1, 2, 3, 4, 5, 6 });
+        Assert.AreEqual(new ushort[] { 1, 2, 3, 4, 5, 6 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new ushort[] { 6, 5, 4, 3, 2, 1 });
+        Assert.AreEqual(new ushort[] { 6, 5, 4, 3, 2, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new ushort[] { 3, 2, 1, 6, 5, 4 });
+        Assert.AreEqual(new ushort[] { 3, 2, 1, 6, 5, 4 }, result);
       }
     }
     #endregion
@@ -694,16 +694,16 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Vec32F1, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new float[] { 4.0f / 255, 5.0f / 255, 6.0f / 255, 1.0f / 255, 2.0f / 255, 3.0f / 255 });
+        Assert.AreEqual(new float[] { 4.0f / 255, 5.0f / 255, 6.0f / 255, 1.0f / 255, 2.0f / 255, 3.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new float[] { 1.0f / 255, 2.0f / 255, 3.0f / 255, 4.0f / 255, 5.0f / 255, 6.0f / 255 });
+        Assert.AreEqual(new float[] { 1.0f / 255, 2.0f / 255, 3.0f / 255, 4.0f / 255, 5.0f / 255, 6.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new float[] { 6.0f / 255, 5.0f / 255, 4.0f / 255, 3.0f / 255, 2.0f / 255, 1.0f / 255 });
+        Assert.AreEqual(new float[] { 6.0f / 255, 5.0f / 255, 4.0f / 255, 3.0f / 255, 2.0f / 255, 1.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new float[] { 3.0f / 255, 2.0f / 255, 1.0f / 255, 6.0f / 255, 5.0f / 255, 4.0f / 255 });
+        Assert.AreEqual(new float[] { 3.0f / 255, 2.0f / 255, 1.0f / 255, 6.0f / 255, 5.0f / 255, 4.0f / 255 }, result);
       }
     }
 
@@ -722,28 +722,28 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Vec32F2, 3, 2, 32, bytes))
       {
         Assert.True(imageFrame.TryReadChannel(0, result, false, false));
-        Assert.AreEqual(result, new float[] { 9.0f / 255, 41.0f / 255, 73.0f / 255, 1.0f / 255, 33.0f / 255, 65.0f / 255 });
+        Assert.AreEqual(new float[] { 9.0f / 255, 41.0f / 255, 73.0f / 255, 1.0f / 255, 33.0f / 255, 65.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, false, true));
-        Assert.AreEqual(result, new float[] { 1.0f / 255, 33.0f / 255, 65.0f / 255, 9.0f / 255, 41.0f / 255, 73.0f / 255 });
+        Assert.AreEqual(new float[] { 1.0f / 255, 33.0f / 255, 65.0f / 255, 9.0f / 255, 41.0f / 255, 73.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, false));
-        Assert.AreEqual(result, new float[] { 73.0f / 255, 41.0f / 255, 9.0f / 255, 65.0f / 255, 33.0f / 255, 1.0f / 255 });
+        Assert.AreEqual(new float[] { 73.0f / 255, 41.0f / 255, 9.0f / 255, 65.0f / 255, 33.0f / 255, 1.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(0, result, true, true));
-        Assert.AreEqual(result, new float[] { 65.0f / 255, 33.0f / 255, 1.0f / 255, 73.0f / 255, 41.0f / 255, 9.0f / 255 });
+        Assert.AreEqual(new float[] { 65.0f / 255, 33.0f / 255, 1.0f / 255, 73.0f / 255, 41.0f / 255, 9.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, false));
-        Assert.AreEqual(result, new float[] { 10.0f / 255, 42.0f / 255, 74.0f / 255, 2.0f / 255, 34.0f / 255, 66.0f / 255 });
+        Assert.AreEqual(new float[] { 10.0f / 255, 42.0f / 255, 74.0f / 255, 2.0f / 255, 34.0f / 255, 66.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, false, true));
-        Assert.AreEqual(result, new float[] { 2.0f / 255, 34.0f / 255, 66.0f / 255, 10.0f / 255, 42.0f / 255, 74.0f / 255 });
+        Assert.AreEqual(new float[] { 2.0f / 255, 34.0f / 255, 66.0f / 255, 10.0f / 255, 42.0f / 255, 74.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, false));
-        Assert.AreEqual(result, new float[] { 74.0f / 255, 42.0f / 255, 10.0f / 255, 66.0f / 255, 34.0f / 255, 2.0f / 255 });
+        Assert.AreEqual(new float[] { 74.0f / 255, 42.0f / 255, 10.0f / 255, 66.0f / 255, 34.0f / 255, 2.0f / 255 }, result);
 
         Assert.True(imageFrame.TryReadChannel(1, result, true, true));
-        Assert.AreEqual(result, new float[] { 66.0f / 255, 34.0f / 255, 2.0f / 255, 74.0f / 255, 42.0f / 255, 10.0f / 255 });
+        Assert.AreEqual(new float[] { 66.0f / 255, 34.0f / 255, 2.0f / 255, 74.0f / 255, 42.0f / 255, 10.0f / 255 }, result);
       }
     }
     #endregion
@@ -880,52 +880,52 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, false));
-        AssertNormalized(result, new byte[] { 9, 41, 73, 1, 33, 65 });
+        AssertNormalized(new byte[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, true));
-        AssertNormalized(result, new byte[] { 1, 33, 65, 9, 41, 73 });
+        AssertNormalized(new byte[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, false));
-        AssertNormalized(result, new byte[] { 73, 41, 9, 65, 33, 1 });
+        AssertNormalized(new byte[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, true));
-        AssertNormalized(result, new byte[] { 65, 33, 1, 73, 41, 9 });
+        AssertNormalized(new byte[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, false, false));
-        AssertNormalized(result, new byte[] { 10, 42, 74, 2, 34, 66 });
+        AssertNormalized(new byte[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, false, true));
-        AssertNormalized(result, new byte[] { 2, 34, 66, 10, 42, 74 });
+        AssertNormalized(new byte[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, true, false));
-        AssertNormalized(result, new byte[] { 74, 42, 10, 66, 34, 2 });
+        AssertNormalized(new byte[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, true, true));
-        AssertNormalized(result, new byte[] { 66, 34, 2, 74, 42, 10 });
+        AssertNormalized(new byte[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, false, false));
-        AssertNormalized(result, new byte[] { 11, 43, 75, 3, 35, 67 });
+        AssertNormalized(new byte[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, false, true));
-        AssertNormalized(result, new byte[] { 3, 35, 67, 11, 43, 75 });
+        AssertNormalized(new byte[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, true, false));
-        AssertNormalized(result, new byte[] { 75, 43, 11, 67, 35, 3 });
+        AssertNormalized(new byte[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, true, true));
-        AssertNormalized(result, new byte[] { 67, 35, 3, 75, 43, 11 });
+        AssertNormalized(new byte[] { 67, 35, 3, 75, 43, 11 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, false, false));
-        AssertNormalized(result, new byte[] { 12, 44, 76, 4, 36, 68 });
+        AssertNormalized(new byte[] { 12, 44, 76, 4, 36, 68 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, false, true));
-        AssertNormalized(result, new byte[] { 4, 36, 68, 12, 44, 76 });
+        AssertNormalized(new byte[] { 4, 36, 68, 12, 44, 76 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, true, false));
-        AssertNormalized(result, new byte[] { 76, 44, 12, 68, 36, 4 });
+        AssertNormalized(new byte[] { 76, 44, 12, 68, 36, 4 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, true, true));
-        AssertNormalized(result, new byte[] { 68, 36, 4, 76, 44, 12 });
+        AssertNormalized(new byte[] { 68, 36, 4, 76, 44, 12 }, result);
       }
     }
 
@@ -942,16 +942,16 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray8, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, false));
-        AssertNormalized(result, new byte[] { 4, 5, 6, 1, 2, 3 });
+        AssertNormalized(new byte[] { 4, 5, 6, 1, 2, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, true));
-        AssertNormalized(result, new byte[] { 1, 2, 3, 4, 5, 6 });
+        AssertNormalized(new byte[] { 1, 2, 3, 4, 5, 6 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, false));
-        AssertNormalized(result, new byte[] { 6, 5, 4, 3, 2, 1 });
+        AssertNormalized(new byte[] { 6, 5, 4, 3, 2, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, true));
-        AssertNormalized(result, new byte[] { 3, 2, 1, 6, 5, 4 });
+        AssertNormalized(new byte[] { 3, 2, 1, 6, 5, 4 }, result);
       }
     }
 
@@ -969,52 +969,52 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba64, 3, 2, 24, bytes))
       {
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, false));
-        AssertNormalized(result, new ushort[] { 9, 41, 73, 1, 33, 65 });
+        AssertNormalized(new ushort[] { 9, 41, 73, 1, 33, 65 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, true));
-        AssertNormalized(result, new ushort[] { 1, 33, 65, 9, 41, 73 });
+        AssertNormalized(new ushort[] { 1, 33, 65, 9, 41, 73 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, false));
-        AssertNormalized(result, new ushort[] { 73, 41, 9, 65, 33, 1 });
+        AssertNormalized(new ushort[] { 73, 41, 9, 65, 33, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, true));
-        AssertNormalized(result, new ushort[] { 65, 33, 1, 73, 41, 9 });
+        AssertNormalized(new ushort[] { 65, 33, 1, 73, 41, 9 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, false, false));
-        AssertNormalized(result, new ushort[] { 10, 42, 74, 2, 34, 66 });
+        AssertNormalized(new ushort[] { 10, 42, 74, 2, 34, 66 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, false, true));
-        AssertNormalized(result, new ushort[] { 2, 34, 66, 10, 42, 74 });
+        AssertNormalized(new ushort[] { 2, 34, 66, 10, 42, 74 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, true, false));
-        AssertNormalized(result, new ushort[] { 74, 42, 10, 66, 34, 2 });
+        AssertNormalized(new ushort[] { 74, 42, 10, 66, 34, 2 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(1, result, true, true));
-        AssertNormalized(result, new ushort[] { 66, 34, 2, 74, 42, 10 });
+        AssertNormalized(new ushort[] { 66, 34, 2, 74, 42, 10 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, false, false));
-        AssertNormalized(result, new ushort[] { 11, 43, 75, 3, 35, 67 });
+        AssertNormalized(new ushort[] { 11, 43, 75, 3, 35, 67 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, false, true));
-        AssertNormalized(result, new ushort[] { 3, 35, 67, 11, 43, 75 });
+        AssertNormalized(new ushort[] { 3, 35, 67, 11, 43, 75 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, true, false));
-        AssertNormalized(result, new ushort[] { 75, 43, 11, 67, 35, 3 });
+        AssertNormalized(new ushort[] { 75, 43, 11, 67, 35, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(2, result, true, true));
-        AssertNormalized(result, new ushort[] { 67, 35, 3, 75, 43, 11 });
+        AssertNormalized(new ushort[] { 67, 35, 3, 75, 43, 11 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, false, false));
-        AssertNormalized(result, new ushort[] { 12, 44, 76, 4, 36, 68 });
+        AssertNormalized(new ushort[] { 12, 44, 76, 4, 36, 68 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, false, true));
-        AssertNormalized(result, new ushort[] { 4, 36, 68, 12, 44, 76 });
+        AssertNormalized(new ushort[] { 4, 36, 68, 12, 44, 76 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, true, false));
-        AssertNormalized(result, new ushort[] { 76, 44, 12, 68, 36, 4 });
+        AssertNormalized(new ushort[] { 76, 44, 12, 68, 36, 4 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(3, result, true, true));
-        AssertNormalized(result, new ushort[] { 68, 36, 4, 76, 44, 12 });
+        AssertNormalized(new ushort[] { 68, 36, 4, 76, 44, 12 }, result);
       }
     }
 
@@ -1031,16 +1031,16 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray16, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, false));
-        AssertNormalized(result, new ushort[] { 4, 5, 6, 1, 2, 3 });
+        AssertNormalized(new ushort[] { 4, 5, 6, 1, 2, 3 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, false, true));
-        AssertNormalized(result, new ushort[] { 1, 2, 3, 4, 5, 6 });
+        AssertNormalized(new ushort[] { 1, 2, 3, 4, 5, 6 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, false));
-        AssertNormalized(result, new ushort[] { 6, 5, 4, 3, 2, 1 });
+        AssertNormalized(new ushort[] { 6, 5, 4, 3, 2, 1 }, result);
 
         Assert.True(imageFrame.TryReadChannelNormalized(0, result, true, true));
-        AssertNormalized(result, new ushort[] { 3, 2, 1, 6, 5, 4 });
+        AssertNormalized(new ushort[] { 3, 2, 1, 6, 5, 4 }, result);
       }
     }
     #endregion
@@ -1082,7 +1082,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgb, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1104,7 +1104,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1126,7 +1126,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Sbgra, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1147,7 +1147,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray8, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1172,7 +1172,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Lab8, 5, 4, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1194,7 +1194,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgb48, 3, 2, 24, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1216,7 +1216,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Srgba64, 3, 2, 24, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1237,7 +1237,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Gray16, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
 
@@ -1259,7 +1259,7 @@ namespace Tests
       using (var imageFrame = BuildImageFrame(ImageFormat.Types.Format.Vec32F1, 3, 2, 16, bytes))
       {
         Assert.True(imageFrame.TryReadPixelData(result));
-        Assert.AreEqual(result, expected);
+        Assert.AreEqual(expected, result);
       }
     }
     #endregion
@@ -1290,22 +1290,22 @@ namespace Tests
       return bytes;
     }
 
-    private void AssertNormalized(float[] result, byte[] expectedUnnormalized)
+    private void AssertNormalized(byte[] expectedUnnormalized, float[] result)
     {
       Assert.True(result.All((v) => v >= 0.0f && v <= 1.0f));
-      AreAlmostEqual(result, expectedUnnormalized.Select((v) => (float)v / 255).ToArray(), 1e-6);
+      AreAlmostEqual(expectedUnnormalized.Select((v) => (float)v / 255).ToArray(), result, 1e-6);
     }
 
-    private void AssertNormalized(float[] result, ushort[] expectedUnnormalized)
+    private void AssertNormalized(ushort[] expectedUnnormalized, float[] result)
     {
       Assert.True(result.All((v) => v >= 0.0f && v <= 1.0f));
-      AreAlmostEqual(result, expectedUnnormalized.Select((v) => (float)v / 65525).ToArray(), 1e-6);
+      AreAlmostEqual(expectedUnnormalized.Select((v) => (float)v / 65525).ToArray(), result, 1e-6);
     }
 
-    private void AreAlmostEqual(float[] xs, float[] ys, double threshold)
+    private void AreAlmostEqual(float[] expected, float[] actual, double threshold)
     {
-      Assert.AreEqual(xs.Length, ys.Length);
-      Assert.True(xs.Zip(ys, (x, y) => x - y).All((diff) => Mathf.Abs(diff) < threshold));
+      Assert.AreEqual(expected.Length, actual.Length);
+      Assert.True(expected.Zip(actual, (x, y) => x - y).All((diff) => Mathf.Abs(diff) < threshold));
     }
   }
 }


### PR DESCRIPTION
The `expected` and `actual` arguments of `Assert.AreEqual` are interchanged, so this PR changes them back.
`namespace` of `Tests.dll` will also be changed.