### PR TITLE
chore: dump version in package.json etc

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,20 @@
+{
+  "bumpFiles": [
+    {
+      "filename": "Packages/com.github.homuler.mediapipe/package.json",
+      "type": "json"
+    },
+    {
+      "filename": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "updater": "issue-template-version-updater.js"
+    },
+    {
+      "filename": ".github/ISSUE_TEMPLATE/build-install-issue.yml",
+      "updater": "issue-template-version-updater.js"
+    },
+    {
+      "filename": ".github/ISSUE_TEMPLATE/support.yml",
+      "updater": "issue-template-version-updater.js"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ node {
 }
 ```
 
+For more detailed usage, see [the API Overview](https://github.com/homuler/MediaPipeUnityPlugin/wiki/API-Overview) page or the tutorial on [the Getting Started page](https://github.com/homuler/MediaPipeUnityPlugin/wiki/Getting-Started).
+
 ## :hammer_and_wrench: Installation
 
 This repository does not contain required libraries (e.g. `libmediapipe_c.so`, `Google.Protobuf.dll`, etc), so you **need to build them** first.\
@@ -122,7 +124,7 @@ Make sure that you select `GPU` for inference mode before building the app, beca
 
 ## :book: Wiki
 
-:construction: https://github.com/homuler/MediaPipeUnityPlugin/wiki
+https://github.com/homuler/MediaPipeUnityPlugin/wiki
 
 ## :scroll: LICENSE
 

--- a/issue-template-version-updater.js
+++ b/issue-template-version-updater.js
@@ -1,0 +1,13 @@
+module.exports.readVersion = function (contents) {
+  var pluginVersionIdPos = contents.indexOf("id: plugin_version");
+  var matchedVersion = contents.substring(pluginVersionIdPos).match(/placeholder: v(.*)/);
+  return matchedVersion[1];
+};
+
+module.exports.writeVersion = function (contents, version) {
+  var pluginVersionIdPos = contents.indexOf("id: plugin_version");
+  var matchedVersion = contents.substring(pluginVersionIdPos).match(/placeholder: v(.*)/);
+  var versionStartPos = pluginVersionIdPos + matchedVersion.index;
+  var versionEndPos = versionStartPos + matchedVersion[0].length;
+  return contents.substring(0, versionStartPos) + `placeholder: v${version}` + contents.substring(versionEndPos);
+};


### PR DESCRIPTION
This change is based on https://github.com/conventional-changelog/standard-version#can-i-use-standard-version-for-additional-metadata-files-languages-or-version-files.