### PR TITLE
feat(plugin): mediapipe v0.8.10

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,8 +25,19 @@ build:macos --cxxopt=-std=c++17
 build:macos --host_cxxopt=-std=c++17
 build:macos --copt=-w
 
+build:darwin_x86_64 --apple_platform_type=macos
+build:darwin_x86_64 --macos_minimum_os=10.12
+build:darwin_x86_64 --cpu=darwin_x86_64
+
+build:darwin_arm64 --apple_platform_type=macos
+build:darwin_arm64 --macos_minimum_os=10.16
+build:darwin_arm64 --cpu=darwin_arm64
+
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
+
+# Compile ObjC++ files with C++17
+build --per_file_copt=.*\.mm\$@-std=c++17
 
 # Android configs.
 # Note: the documentation tells us to use @androidndk//:default_crosstool, but
@@ -58,6 +69,7 @@ build:android_fat --cpu=arm64-v8a
 build:android_fat --fat_apk_cpu=armeabi-v7a,arm64-v8a
 
 build:ios --apple_platform_type=ios
+build:ios --copt=-fno-aligned-allocation
 
 build:ios_i386 --config=ios
 build:ios_i386 --cpu=ios_i386

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GpuBuffer.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Gpu/GpuBuffer.cs
@@ -26,13 +26,6 @@ namespace Mediapipe
       UnsafeNativeMethods.mp_GpuBuffer__delete(ptr);
     }
 
-#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_ANDROID
-    public GlTextureBuffer GetGlTextureBuffer()
-    {
-      return new GlTextureBuffer(SafeNativeMethods.mp_GpuBuffer__GetGlTextureBufferSharedPtr(mpPtr), false);
-    }
-#endif
-
     public GpuBufferFormat Format()
     {
       return SafeNativeMethods.mp_GpuBuffer__format(mpPtr);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Gpu/GpuBuffer_Safe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Gpu/GpuBuffer_Safe.cs
@@ -12,11 +12,6 @@ namespace Mediapipe
 {
   internal static partial class SafeNativeMethods
   {
-#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_ANDROID
-    [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
-    public static extern IntPtr mp_GpuBuffer__GetGlTextureBufferSharedPtr(IntPtr gpuBuffer);
-#endif
-
     [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern int mp_GpuBuffer__width(IntPtr gpuBuffer);
 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensorflow.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Calculators/Tensorflow.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7e404aee7ae86016eb998cd313cb9407
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/LabelMap.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/Util/LabelMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ba80c98bd33fbabd8c5d441c95fe506
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MediaPipe Unity Plugin
 
-This is a Unity (2020.3.30f1) [Native Plugin](https://docs.unity3d.com/Manual/NativePlugins.html) to use [MediaPipe](https://github.com/google/mediapipe) (0.8.9).
+This is a Unity (2020.3.30f1) [Native Plugin](https://docs.unity3d.com/Manual/NativePlugins.html) to use [MediaPipe](https://github.com/google/mediapipe) (0.8.10).
 
 The goal of this project is to port the MediaPipe API (C++) _one by one_ to C# so that it can be called from Unity.\
 This approach may sacrifice performance when you need to call multiple APIs in a loop, but it gives you the flexibility to use MediaPipe instead.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,7 +63,7 @@ http_archive(
         "@//third_party:mediapipe_visibility.diff",
         "@//third_party:mediapipe_model_path.diff",
         "@//third_party:mediapipe_extension.diff",
-        "@//third_party:mediapipe_emscripten_patch.diff",
+        # "@//third_party:mediapipe_emscripten_patch.diff",
     ],
     sha256 = "6b43a4304ca4aa3a698906e4b4ff696d698d0b788baffd8284c03632712b1020",
     strip_prefix = "mediapipe-0.8.10",
@@ -414,7 +414,7 @@ http_archive(
         "@com_google_mediapipe//third_party:org_tensorflow_compatibility_fixes.diff",
         # Diff is generated with a script, don't update it manually.
         "@com_google_mediapipe//third_party:org_tensorflow_custom_ops.diff",
-        "@//third_party:tensorflow_xnnpack_emscripten_fixes.diff",
+        # "@//third_party:tensorflow_xnnpack_emscripten_fixes.diff",
     ],
     sha256 = _TENSORFLOW_SHA256,
     strip_prefix = "tensorflow-%s" % _TENSORFLOW_GIT_COMMIT,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -65,9 +65,9 @@ http_archive(
         "@//third_party:mediapipe_extension.diff",
         "@//third_party:mediapipe_emscripten_patch.diff",
     ],
-    sha256 = "54ce6da9f167d34fe53f928c804b3bc1fd1dd8fe2b32ca4bf0b63325d34680ac",
-    strip_prefix = "mediapipe-0.8.9",
-    urls = ["https://github.com/google/mediapipe/archive/v0.8.9.tar.gz"],
+    sha256 = "6b43a4304ca4aa3a698906e4b4ff696d698d0b788baffd8284c03632712b1020",
+    strip_prefix = "mediapipe-0.8.10",
+    urls = ["https://github.com/google/mediapipe/archive/v0.8.10.tar.gz"],
 )
 
 # ABSL cpp library lts_2021_03_24, patch 2.
@@ -122,12 +122,13 @@ http_archive(
     urls = ["https://github.com/google/googletest/archive/4ec4cd23f486bf70efcc5d2caa40f24368f752e3.zip"],
 )
 
-# Google Benchmark library.
+# Google Benchmark library v1.6.1 released on 2022-01-10.
 http_archive(
     name = "com_google_benchmark",
     build_file = "@com_google_mediapipe//third_party:benchmark.BUILD",
-    strip_prefix = "benchmark-main",
-    urls = ["https://github.com/google/benchmark/archive/main.zip"],
+    sha256 = "6132883bc8c9b0df5375b16ab520fac1a85dc9e4cf5be59480448ece74b278d4",
+    strip_prefix = "benchmark-1.6.1",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz"],
 )
 
 # gflags needed by glog
@@ -399,10 +400,10 @@ http_archive(
 )
 
 # Tensorflow repo should always go after the other external dependencies.
-# 2021-12-02
-_TENSORFLOW_GIT_COMMIT = "18a1dc0ba806dc023808531f0373d9ec068e64bf"
+# 2022-02-15
+_TENSORFLOW_GIT_COMMIT = "a3419acc751dfc19caf4d34a1594e1f76810ec58"
 
-_TENSORFLOW_SHA256 = "85b90416f7a11339327777bccd634de00ca0de2cf334f5f0727edcb11ff9289a"
+_TENSORFLOW_SHA256 = "b95b2a83632d4055742ae1a2dcc96b45da6c12a339462dbc76c8bca505308e3a"
 
 http_archive(
     name = "org_tensorflow",
@@ -411,7 +412,6 @@ http_archive(
     ],
     patches = [
         "@com_google_mediapipe//third_party:org_tensorflow_compatibility_fixes.diff",
-        "@com_google_mediapipe//third_party:org_tensorflow_objc_cxx17.diff",
         # Diff is generated with a script, don't update it manually.
         "@com_google_mediapipe//third_party:org_tensorflow_custom_ops.diff",
         "@//third_party:tensorflow_xnnpack_emscripten_fixes.diff",

--- a/mediapipe_api/calculators/util/BUILD
+++ b/mediapipe_api/calculators/util/BUILD
@@ -65,6 +65,7 @@ csharp_proto_src(
     deps = [
         "@com_google_mediapipe//mediapipe/calculators/util:protos_src",
         "@com_google_mediapipe//mediapipe/framework:protos_src",
+        "@com_google_mediapipe//mediapipe/util:protos_src",
     ],
 )
 

--- a/mediapipe_api/gpu/gpu_buffer.cc
+++ b/mediapipe_api/gpu/gpu_buffer.cc
@@ -18,8 +18,6 @@ MpReturnCode mp_GpuBuffer__PSgtb(SharedGlTextureBuffer* gl_texture_buffer, media
     RETURN_CODE(MpReturnCode::Success);
   CATCH_EXCEPTION
 }
-
-const SharedGlTextureBuffer& mp_GpuBuffer__GetGlTextureBufferSharedPtr(mediapipe::GpuBuffer* gpu_buffer) { return gpu_buffer->GetGlTextureBufferSharedPtr(); }
 #endif  // MEDIAPIPE_GPU_BUFFER_USE_CV_PIXEL_BUFFER
 
 int mp_GpuBuffer__width(mediapipe::GpuBuffer* gpu_buffer) { return gpu_buffer->width(); }

--- a/mediapipe_api/gpu/gpu_buffer.h
+++ b/mediapipe_api/gpu/gpu_buffer.h
@@ -26,7 +26,6 @@ MP_CAPI(void) mp_GpuBuffer__delete(mediapipe::GpuBuffer* gpu_buffer);
 // TODO
 #else
 MP_CAPI(MpReturnCode) mp_GpuBuffer__PSgtb(SharedGlTextureBuffer* gl_texture_buffer, mediapipe::GpuBuffer** gpu_buffer_out);
-MP_CAPI(const SharedGlTextureBuffer&) mp_GpuBuffer__GetGlTextureBufferSharedPtr(mediapipe::GpuBuffer* gpu_buffer);
 #endif  // MEDIAPIPE_GPU_BUFFER_USE_CV_PIXEL_BUFFER
 
 MP_CAPI(int) mp_GpuBuffer__width(mediapipe::GpuBuffer* gpu_buffer);

--- a/mediapipe_api/modules/iris_landmark/BUILD
+++ b/mediapipe_api/modules/iris_landmark/BUILD
@@ -16,8 +16,8 @@ mediapipe_simple_subgraph(
     graph = "iris_landmarks_from_face_landmarks_gpu.pbtxt",
     register_as = "IrisLandmarksFromFaceLandmarksGpu",
     deps = [
-        "@com_google_mediapipe//mediapipe/calculators/core:concatenate_normalized_landmark_list_calculator",
-        "@com_google_mediapipe//mediapipe/calculators/core:split_landmarks_calculator",
+        "@com_google_mediapipe//mediapipe/calculators/core:concatenate_proto_list_calculator",
+        "@com_google_mediapipe//mediapipe/calculators/core:split_proto_list_calculator",
         "@com_google_mediapipe//mediapipe/graphs/iris_tracking/calculators:update_face_landmarks_calculator",
         "@com_google_mediapipe//mediapipe/modules/iris_landmark:iris_landmark_left_and_right_gpu",
     ],
@@ -28,8 +28,8 @@ mediapipe_simple_subgraph(
     graph = "iris_landmarks_from_face_landmarks_cpu.pbtxt",
     register_as = "IrisLandmarksFromFaceLandmarksCpu",
     deps = [
-        "@com_google_mediapipe//mediapipe/calculators/core:concatenate_normalized_landmark_list_calculator",
-        "@com_google_mediapipe//mediapipe/calculators/core:split_landmarks_calculator",
+        "@com_google_mediapipe//mediapipe/calculators/core:concatenate_proto_list_calculator",
+        "@com_google_mediapipe//mediapipe/calculators/core:split_proto_list_calculator",
         "@com_google_mediapipe//mediapipe/graphs/iris_tracking/calculators:update_face_landmarks_calculator",
         "@com_google_mediapipe//mediapipe/modules/iris_landmark:iris_landmark_left_and_right_cpu",
     ],

--- a/mediapipe_api/util/BUILD
+++ b/mediapipe_api/util/BUILD
@@ -30,6 +30,7 @@ pkg_files(
     srcs = [
         ":audio_decoder_cs",
         ":color_cs",
+        ":label_map_cs",
         ":render_data_cs",
     ],
     prefix = "Util",
@@ -47,6 +48,14 @@ csharp_proto_src(
 csharp_proto_src(
     name = "color_cs",
     proto_src = "mediapipe/util/color.proto",
+    deps = [
+        "@com_google_mediapipe//mediapipe/util:protos_src",
+    ],
+)
+
+csharp_proto_src(
+    name = "label_map_cs",
+    proto_src = "mediapipe/util/label_map.proto",
     deps = [
         "@com_google_mediapipe//mediapipe/util:protos_src",
     ],

--- a/third_party/mediapipe_emscripten_patch.diff
+++ b/third_party/mediapipe_emscripten_patch.diff
@@ -180,7 +180,7 @@ index 062fb2c..2d9d5ee 100644
  #endif  // !MEDIAPIPE_DISABLE_GPU
  
 diff --git a/mediapipe/calculators/image/segmentation_smoothing_calculator.cc b/mediapipe/calculators/image/segmentation_smoothing_calculator.cc
-index db339b7..817b894 100644
+index 62d3b0d..03d0ff0 100644
 --- a/mediapipe/calculators/image/segmentation_smoothing_calculator.cc
 +++ b/mediapipe/calculators/image/segmentation_smoothing_calculator.cc
 @@ -314,7 +314,7 @@ void SegmentationSmoothingCalculator::GlRender(CalculatorContext* cc) {
@@ -262,7 +262,7 @@ index 6154a24..da4f55e 100644
  
    // parameters
 diff --git a/mediapipe/calculators/tensor/image_to_tensor_converter_gl_buffer.cc b/mediapipe/calculators/tensor/image_to_tensor_converter_gl_buffer.cc
-index d01916f..dbccfd5 100644
+index ddc7ff8..e06b6ee 100644
 --- a/mediapipe/calculators/tensor/image_to_tensor_converter_gl_buffer.cc
 +++ b/mediapipe/calculators/tensor/image_to_tensor_converter_gl_buffer.cc
 @@ -85,7 +85,7 @@ class SubRectExtractorGl {
@@ -275,7 +275,7 @@ index d01916f..dbccfd5 100644
    return TFLITE_GPU_CALL_GL(glProgramUniformMatrix4fv, program.id(), uniform_id,
                              1, GL_TRUE, data);
 diff --git a/mediapipe/calculators/tensor/image_to_tensor_converter_gl_texture.cc b/mediapipe/calculators/tensor/image_to_tensor_converter_gl_texture.cc
-index eb96815..6e07c85 100644
+index 6f035e6..8c6b7f1 100644
 --- a/mediapipe/calculators/tensor/image_to_tensor_converter_gl_texture.cc
 +++ b/mediapipe/calculators/tensor/image_to_tensor_converter_gl_texture.cc
 @@ -140,11 +140,11 @@ class GlProcessor : public ImageToTensorConverter {
@@ -295,7 +295,7 @@ index eb96815..6e07c85 100644
  
        glGenFramebuffers(1, &framebuffer_);
  
-@@ -246,7 +246,7 @@ class GlProcessor : public ImageToTensorConverter {
+@@ -248,7 +248,7 @@ class GlProcessor : public ImageToTensorConverter {
        }
      }
  
@@ -359,10 +359,10 @@ index f3c7c7b..fc157c8 100644
  
  #endif  // MEDIAPIPE_OPENGL_ES_VERSION >= MEDIAPIPE_OPENGL_ES_31
 diff --git a/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc b/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc
-index 498036c..bb12587 100644
+index b1babaf..6f726f4 100644
 --- a/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc
 +++ b/mediapipe/calculators/tensor/tensors_to_detections_calculator.cc
-@@ -420,14 +420,14 @@ absl::Status TensorsToDetectionsCalculator::ProcessGPU(
+@@ -495,7 +495,7 @@ absl::Status TensorsToDetectionsCalculator::ProcessGPU(
        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, input0_view.name());
        auto raw_anchors_view = raw_anchors_buffer_->GetOpenGlBufferReadView();
        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, raw_anchors_view.name());
@@ -371,15 +371,16 @@ index 498036c..bb12587 100644
        glDispatchCompute(num_boxes_, 1, 1);
  
        // Score boxes.
-       glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, scored_boxes_view.name());
-       auto input1_view = input_tensors[1].GetOpenGlBufferReadView();
+@@ -503,7 +503,7 @@ absl::Status TensorsToDetectionsCalculator::ProcessGPU(
+       auto input1_view = input_tensors[tensor_mapping_.scores_tensor_index()]
+                              .GetOpenGlBufferReadView();
        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, input1_view.name());
 -      glUseProgram(score_program_);
 +      __wrap_glUseProgram(score_program_);
        glDispatchCompute(num_boxes_, 1, 1);
      }
      return absl::OkStatus();
-@@ -817,9 +817,9 @@ void main() {
+@@ -949,9 +949,9 @@ void main() {
          options_.keypoint_coord_offset(), options_.num_values_per_keypoint());
  
      // Shader program
@@ -391,7 +392,7 @@ index 498036c..bb12587 100644
      glCompileShader(shader);
      GLint compiled = GL_FALSE;
      glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
-@@ -832,9 +832,9 @@ void main() {
+@@ -964,9 +964,9 @@ void main() {
        return str;
      }();
      decode_program_ = glCreateProgram();
@@ -403,7 +404,7 @@ index 498036c..bb12587 100644
  
      // Outputs
      decoded_boxes_buffer_ =
-@@ -844,7 +844,7 @@ void main() {
+@@ -976,7 +976,7 @@ void main() {
          Tensor::ElementType::kFloat32,
          Tensor::Shape{1, num_boxes_ * kNumCoordsPerBox});
      // Parameters
@@ -412,7 +413,7 @@ index 498036c..bb12587 100644
      glUniform4f(0, options_.x_scale(), options_.y_scale(), options_.w_scale(),
                  options_.h_scale());
  
-@@ -922,17 +922,17 @@ void main() {
+@@ -1061,17 +1061,17 @@ void main() {
  
      // Shader program
      {
@@ -435,10 +436,10 @@ index 498036c..bb12587 100644
  
      // Outputs
 diff --git a/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.cc b/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.cc
-index ffc96b2..821d38a 100644
+index a03a601..fb5fc65 100644
 --- a/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.cc
 +++ b/mediapipe/calculators/tensor/tensors_to_segmentation_calculator.cc
-@@ -456,8 +456,8 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
+@@ -457,8 +457,8 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
          NumGroups(tensor_width, kWorkgroupSize),
          NumGroups(tensor_height, kWorkgroupSize), 1};
  
@@ -449,7 +450,7 @@ index ffc96b2..821d38a 100644
                  tensor_width, tensor_height);
  
      MP_RETURN_IF_ERROR(mask_program_31_->Dispatch(workgroups));
-@@ -513,7 +513,7 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
+@@ -514,7 +514,7 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
      gpu_helper_.BindFramebuffer(small_mask_texture);
      glActiveTexture(GL_TEXTURE1);
      glBindTexture(GL_TEXTURE_2D, read_view.name());
@@ -458,7 +459,7 @@ index ffc96b2..821d38a 100644
      GlRender();
      glBindTexture(GL_TEXTURE_2D, 0);
      glFlush();
-@@ -534,7 +534,7 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
+@@ -535,7 +535,7 @@ absl::Status TensorsToSegmentationCalculator::ProcessGpu(
  #else
      glBindTexture(GL_TEXTURE_2D, small_mask_texture.name());
  #endif  // MEDIAPIPE_OPENGL_ES_VERSION >= MEDIAPIPE_OPENGL_ES_31
@@ -467,7 +468,7 @@ index ffc96b2..821d38a 100644
      GlRender();
      glBindTexture(GL_TEXTURE_2D, 0);
      glFlush();
-@@ -859,8 +859,8 @@ void main() {
+@@ -860,8 +860,8 @@ void main() {
          mediapipe::kBasicVertexShader, shader_src_no_previous.c_str(),
          NUM_ATTRIBUTES, &attr_name[0], attr_location, &mask_program_20_);
      RET_CHECK(mask_program_20_) << "Problem initializing the program.";
@@ -478,7 +479,7 @@ index ffc96b2..821d38a 100644
  #endif  // MEDIAPIPE_OPENGL_ES_VERSION >= MEDIAPIPE_OPENGL_ES_31
  
      // Simple pass-through program, used for hardware upsampling.
-@@ -868,8 +868,8 @@ void main() {
+@@ -869,8 +869,8 @@ void main() {
          mediapipe::kBasicVertexShader, mediapipe::kBasicTexturedFragmentShader,
          NUM_ATTRIBUTES, &attr_name[0], attr_location, &upsample_program_);
      RET_CHECK(upsample_program_) << "Problem initializing the program.";
@@ -503,10 +504,10 @@ index 2ed62c4..0342586 100644
                  options_.h_scale());
  
 diff --git a/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.cc b/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.cc
-index 22a9a8d..2372976 100644
+index ff1d1aa..078f1d8 100644
 --- a/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.cc
 +++ b/mediapipe/calculators/tflite/tflite_tensors_to_segmentation_calculator.cc
-@@ -477,7 +477,7 @@ void TfLiteTensorsToSegmentationCalculator::GlRender() {
+@@ -478,7 +478,7 @@ void TfLiteTensorsToSegmentationCalculator::GlRender() {
    };
  
    // program
@@ -515,7 +516,7 @@ index 22a9a8d..2372976 100644
  
    // vertex storage
    GLuint vbo[2];
-@@ -637,17 +637,17 @@ void main() {
+@@ -638,17 +638,17 @@ void main() {
          tensor_length, tensor_buffer_.get()));
  
      // Parameters.
@@ -539,7 +540,7 @@ index 22a9a8d..2372976 100644
  
      // Vertex shader attributes.
      const GLint attr_location[NUM_ATTRIBUTES] = {
-@@ -692,8 +692,8 @@ void main() {
+@@ -693,8 +693,8 @@ void main() {
      RET_CHECK(upsample_program_) << "Problem initializing the program.";
  
      // Parameters
@@ -579,10 +580,10 @@ index 8af4a5d..ed6ec5c 100644
                kAnnotationBackgroundColor / 255.0,
                kAnnotationBackgroundColor / 255.0);
 diff --git a/mediapipe/gpu/BUILD b/mediapipe/gpu/BUILD
-index 2d163b4..edea795 100644
+index 8c9c433..4afcb29 100644
 --- a/mediapipe/gpu/BUILD
 +++ b/mediapipe/gpu/BUILD
-@@ -97,7 +97,7 @@ cc_library(
+@@ -104,7 +104,7 @@ cc_library(
      linkopts = GL_BASE_LINK_OPTS_OSS,
      textual_hdrs = ["gl_base.h"],
      visibility = ["//visibility:public"],
@@ -591,7 +592,7 @@ index 2d163b4..edea795 100644
          "//mediapipe:android": [],
          "//mediapipe:apple": [],
          "//conditions:default": [
-@@ -107,7 +107,9 @@ cc_library(
+@@ -114,7 +114,9 @@ cc_library(
  
  cc_library(
      name = "gl_base_hdr",
@@ -602,7 +603,7 @@ index 2d163b4..edea795 100644
      features = ["-layering_check"],
      # Note: need the frameworks on Apple platforms to get the headers.
      linkopts = select({
-@@ -130,6 +132,21 @@ cc_library(
+@@ -137,6 +139,21 @@ cc_library(
      }),
  )
  
@@ -624,19 +625,19 @@ index 2d163b4..edea795 100644
  cc_library(
      name = "gl_thread_collector",
      hdrs = ["gl_thread_collector.h"],
-@@ -166,6 +183,7 @@ cc_library(
+@@ -173,6 +190,7 @@ cc_library(
      visibility = ["//visibility:public"],
      deps = [
          ":gl_base",
 +        ":gl_wrapper",
          ":gl_thread_collector",
          ":gpu_buffer_format",
-         "//mediapipe/framework:executor",
+         "@com_google_absl//absl/status",
 diff --git a/mediapipe/gpu/gl_calculator_helper.h b/mediapipe/gpu/gl_calculator_helper.h
-index 5ac0ab1..dddc3ba 100644
+index e445232..0d04c24 100644
 --- a/mediapipe/gpu/gl_calculator_helper.h
 +++ b/mediapipe/gpu/gl_calculator_helper.h
-@@ -25,6 +25,7 @@
+@@ -27,6 +27,7 @@
  #include "mediapipe/framework/packet_type.h"
  #include "mediapipe/framework/port/status.h"
  #include "mediapipe/gpu/gl_base.h"
@@ -645,10 +646,10 @@ index 5ac0ab1..dddc3ba 100644
  #include "mediapipe/gpu/gpu_buffer.h"
  #include "mediapipe/gpu/graph_support.h"
 diff --git a/mediapipe/gpu/gl_context.h b/mediapipe/gpu/gl_context.h
-index 6cab706..2138e0f 100644
+index 7f1fbbb..c3613d8 100644
 --- a/mediapipe/gpu/gl_context.h
 +++ b/mediapipe/gpu/gl_context.h
-@@ -29,6 +29,7 @@
+@@ -30,6 +30,7 @@
  #include "mediapipe/framework/port/threadpool.h"
  #include "mediapipe/framework/timestamp.h"
  #include "mediapipe/gpu/gl_base.h"
@@ -657,10 +658,10 @@ index 6cab706..2138e0f 100644
  
  #ifdef __APPLE__
 diff --git a/mediapipe/gpu/gl_context_egl.cc b/mediapipe/gpu/gl_context_egl.cc
-index 9386f2c..972dbae 100644
+index 75eeeb9..27ace26 100644
 --- a/mediapipe/gpu/gl_context_egl.cc
 +++ b/mediapipe/gpu/gl_context_egl.cc
-@@ -190,7 +190,7 @@ void GlContext::DestroyContext() {
+@@ -206,7 +206,7 @@ void GlContext::DestroyContext() {
        // Note: cannot use ThisContextBinding because it calls shared_from_this,
        // which is not available during destruction.
        if (eglMakeCurrent(display_, surface_, surface_, context_)) {
@@ -670,7 +671,7 @@ index 9386f2c..972dbae 100644
          LOG(ERROR) << "eglMakeCurrent() returned error " << std::showbase
                     << std::hex << eglGetError();
 diff --git a/mediapipe/gpu/gl_quad_renderer.cc b/mediapipe/gpu/gl_quad_renderer.cc
-index c25a37e..e9fe4c2 100644
+index 309b832..757b95f 100644
 --- a/mediapipe/gpu/gl_quad_renderer.cc
 +++ b/mediapipe/gpu/gl_quad_renderer.cc
 @@ -77,11 +77,11 @@ absl::Status QuadRenderer::GlSetup(
@@ -688,7 +689,7 @@ index c25a37e..e9fe4c2 100644
  
    glGenVertexArrays(1, &vao_);
 @@ -114,7 +114,7 @@ absl::Status QuadRenderer::GlRender(float frame_width, float frame_height,
-                                     bool flip_texture) {
+                                     bool flip_texture) const {
    RET_CHECK(program_) << "Must setup the program before rendering.";
  
 -  glUseProgram(program_);
@@ -1020,7 +1021,7 @@ index 804e543..839b12b 100644
  namespace mediapipe {
  
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
-index 9bc43ba..4630fc6 100644
+index 3a77e98..b15730f 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
 +++ b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
 @@ -874,17 +874,17 @@ absl::Status GlAnimationOverlayCalculator::GlSetup() {

--- a/third_party/mediapipe_extension.diff
+++ b/third_party/mediapipe_extension.diff
@@ -1,8 +1,8 @@
 diff --git a/mediapipe/BUILD b/mediapipe/BUILD
-index 1171ea6..6c4a7fb 100644
+index 3187c0c..5056a26 100644
 --- a/mediapipe/BUILD
 +++ b/mediapipe/BUILD
-@@ -139,6 +139,31 @@ config_setting(
+@@ -149,6 +149,31 @@ config_setting(
      values = {"cpu": "x64_windows"},
  )
  
@@ -35,10 +35,10 @@ index 1171ea6..6c4a7fb 100644
      ["provisioning_profile.mobileprovision"],
      visibility = ["//visibility:public"],
 diff --git a/mediapipe/calculators/tensor/BUILD b/mediapipe/calculators/tensor/BUILD
-index 72c2f51..d43c261 100644
+index 586fb0d..ba8629d 100644
 --- a/mediapipe/calculators/tensor/BUILD
 +++ b/mediapipe/calculators/tensor/BUILD
-@@ -35,6 +35,7 @@ selects.config_setting_group(
+@@ -37,6 +37,7 @@ selects.config_setting_group(
      name = "compute_shader_unavailable",
      match_any = [
          "//mediapipe/gpu:disable_gpu",
@@ -46,7 +46,7 @@ index 72c2f51..d43c261 100644
      ],
  )
  
-@@ -572,6 +573,11 @@ cc_library(
+@@ -579,6 +580,11 @@ cc_library(
              "//mediapipe/gpu:MPPMetalHelper",
              "//mediapipe/gpu:gpu_buffer",
          ],
@@ -59,10 +59,10 @@ index 72c2f51..d43c261 100644
              ":image_to_tensor_converter_gl_buffer",
              "//mediapipe/gpu:gl_calculator_helper",
 diff --git a/mediapipe/gpu/BUILD b/mediapipe/gpu/BUILD
-index 2d163b4..e925edc 100644
+index 8c9c433..f6bb250 100644
 --- a/mediapipe/gpu/BUILD
 +++ b/mediapipe/gpu/BUILD
-@@ -154,6 +154,9 @@ cc_library(
+@@ -161,6 +161,9 @@ cc_library(
          "//mediapipe:macos": [
              "gl_context_nsgl.cc",
          ],
@@ -73,10 +73,10 @@ index 2d163b4..e925edc 100644
      hdrs = ["gl_context.h"],
      copts = select({
 diff --git a/mediapipe/gpu/gl_calculator_helper.cc b/mediapipe/gpu/gl_calculator_helper.cc
-index d015c59..05dee07 100644
+index ba14239..69de4ff 100644
 --- a/mediapipe/gpu/gl_calculator_helper.cc
 +++ b/mediapipe/gpu/gl_calculator_helper.cc
-@@ -128,6 +128,10 @@ GlTexture GlCalculatorHelper::CreateDestinationTexture(int output_width,
+@@ -142,6 +142,10 @@ GlTexture GlCalculatorHelper::CreateDestinationTexture(int output_width,
    return impl_->CreateDestinationTexture(output_width, output_height, format);
  }
  
@@ -88,10 +88,10 @@ index d015c59..05dee07 100644
    return impl_->GetGlContext();
  }
 diff --git a/mediapipe/gpu/gl_calculator_helper.h b/mediapipe/gpu/gl_calculator_helper.h
-index 5ac0ab1..f4007a0 100644
+index e445232..fe3f481 100644
 --- a/mediapipe/gpu/gl_calculator_helper.h
 +++ b/mediapipe/gpu/gl_calculator_helper.h
-@@ -141,6 +141,8 @@ class GlCalculatorHelper {
+@@ -154,6 +154,8 @@ class GlCalculatorHelper {
        int output_width, int output_height,
        GpuBufferFormat format = GpuBufferFormat::kBGRA32);
  
@@ -101,7 +101,7 @@ index 5ac0ab1..f4007a0 100644
    GLuint framebuffer() const;
  
 diff --git a/mediapipe/gpu/gl_calculator_helper_impl.h b/mediapipe/gpu/gl_calculator_helper_impl.h
-index c17c724..bab2fb2 100644
+index 72b3265..16a7998 100644
 --- a/mediapipe/gpu/gl_calculator_helper_impl.h
 +++ b/mediapipe/gpu/gl_calculator_helper_impl.h
 @@ -49,6 +49,7 @@ class GlCalculatorHelperImpl {
@@ -110,13 +110,13 @@ index c17c724..bab2fb2 100644
                                       GpuBufferFormat format);
 +  GlTexture CreateDestinationTexture(GpuBuffer& gpu_buffer);
  
-   GLuint framebuffer() const { return framebuffer_; }
-   void BindFramebuffer(const GlTexture& dst);
+   GpuBuffer GpuBufferWithImageFrame(std::shared_ptr<ImageFrame> image_frame);
+   GpuBuffer GpuBufferCopyingImageFrame(const ImageFrame& image_frame);
 diff --git a/mediapipe/gpu/gl_calculator_helper_impl_common.cc b/mediapipe/gpu/gl_calculator_helper_impl_common.cc
-index 0bcf089..23419ad 100644
+index 8dd03bf..7d0ec70 100644
 --- a/mediapipe/gpu/gl_calculator_helper_impl_common.cc
 +++ b/mediapipe/gpu/gl_calculator_helper_impl_common.cc
-@@ -143,12 +143,17 @@ std::unique_ptr<GpuBuffer> GlTexture::GetFrame<GpuBuffer>() const {
+@@ -169,12 +169,17 @@ std::unique_ptr<GpuBuffer> GlTexture::GetFrame<GpuBuffer>() const {
  
  GlTexture GlCalculatorHelperImpl::CreateDestinationTexture(
      int width, int height, GpuBufferFormat format) {
@@ -137,7 +137,7 @@ index 0bcf089..23419ad 100644
  }
  
 diff --git a/mediapipe/gpu/gl_context_webgl.cc b/mediapipe/gpu/gl_context_webgl.cc
-index 01fc12d..aed6686 100644
+index b1f5295..57892ab 100644
 --- a/mediapipe/gpu/gl_context_webgl.cc
 +++ b/mediapipe/gpu/gl_context_webgl.cc
 @@ -50,6 +50,10 @@ absl::Status GlContext::CreateContextInternal(
@@ -205,7 +205,7 @@ index 01fc12d..aed6686 100644
    );
    // clang-format on
 diff --git a/mediapipe/gpu/gl_scaler_calculator.cc b/mediapipe/gpu/gl_scaler_calculator.cc
-index fa06c88..0d0bd0c 100644
+index fa06c88..8641788 100644
 --- a/mediapipe/gpu/gl_scaler_calculator.cc
 +++ b/mediapipe/gpu/gl_scaler_calculator.cc
 @@ -12,6 +12,8 @@
@@ -277,7 +277,7 @@ index fa06c88..0d0bd0c 100644
 +    dst = helper_.CreateDestinationTexture(dst_width, dst_height, GetOutputFormat());
 +#else
 +    if (dst_buffer_) {
-+      dst_buffer_.GetGlTextureBufferSharedPtr()->Reuse();
++      dst_buffer_.internal_storage<mediapipe::GlTextureBuffer>()->Reuse();
 +      dst = helper_.CreateDestinationTexture(dst_buffer_);
 +    } else {
 +      dst = helper_.CreateDestinationTexture(dst_width, dst_height, GetOutputFormat());

--- a/third_party/mediapipe_model_path.diff
+++ b/third_party/mediapipe_model_path.diff
@@ -12,7 +12,7 @@ index 87216f4..309a91c 100644
  #include "mediapipe/util/android/file/base/helpers.h"
  #else
 diff --git a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc
-index 794a8a7..62e5284 100644
+index 1d6b941..1f54494 100644
 --- a/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc
 +++ b/mediapipe/calculators/tensorflow/tensorflow_session_from_frozen_graph_calculator.cc
 @@ -36,7 +36,7 @@
@@ -38,11 +38,11 @@ index 4d28b91..b3bfb57 100644
  #include "mediapipe/util/android/file/base/helpers.h"
  #else
 diff --git a/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc b/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc
-index 07fe791..8c2c928 100644
+index 20d1c1c..4c69696 100644
 --- a/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc
 +++ b/mediapipe/calculators/util/detection_label_id_to_text_calculator.cc
 @@ -20,7 +20,7 @@
- #include "mediapipe/framework/port/status.h"
+ #include "mediapipe/util/label_map.pb.h"
  #include "mediapipe/util/resource_util.h"
  
 -#if defined(MEDIAPIPE_MOBILE)
@@ -64,7 +64,7 @@ index 790b426..35504b5 100644
  #include "mediapipe/util/android/file/base/helpers.h"
  #else
 diff --git a/mediapipe/calculators/util/top_k_scores_calculator.cc b/mediapipe/calculators/util/top_k_scores_calculator.cc
-index 42ec571..b2c63b5 100644
+index b6bdf2f..8c2e573 100644
 --- a/mediapipe/calculators/util/top_k_scores_calculator.cc
 +++ b/mediapipe/calculators/util/top_k_scores_calculator.cc
 @@ -30,7 +30,7 @@
@@ -77,7 +77,7 @@ index 42ec571..b2c63b5 100644
  #include "mediapipe/util/android/file/base/helpers.h"
  #else
 diff --git a/mediapipe/calculators/video/box_detector_calculator.cc b/mediapipe/calculators/video/box_detector_calculator.cc
-index 55b5c45..76158af 100644
+index 14ac12e..1f3fc0f 100644
 --- a/mediapipe/calculators/video/box_detector_calculator.cc
 +++ b/mediapipe/calculators/video/box_detector_calculator.cc
 @@ -38,7 +38,7 @@
@@ -115,7 +115,7 @@ index 8f80312..45b8c53 100644
      alwayslink = 1,
  )
 diff --git a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
-index 9bc43ba..088f8f8 100644
+index 3a77e98..946bc73 100644
 --- a/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
 +++ b/mediapipe/graphs/object_detection_3d/calculators/gl_animation_overlay_calculator.cc
 @@ -12,12 +12,8 @@
@@ -336,16 +336,17 @@ index 9bc43ba..088f8f8 100644
      LOG(ERROR) << "Failed to load animation asset.";
      return absl::UnknownError("Failed to load animation asset.");
 diff --git a/mediapipe/util/BUILD b/mediapipe/util/BUILD
-index a1b179a..7395bb5 100644
+index 12a34a4..36d922f 100644
 --- a/mediapipe/util/BUILD
 +++ b/mediapipe/util/BUILD
-@@ -155,12 +155,8 @@ cc_library(
+@@ -174,13 +174,8 @@ cc_library(
      srcs = [
          "resource_util.cc",
          "resource_util_internal.h",
 -    ] + select({
 -        "//conditions:default": ["resource_util_default.cc"],
 -        "//mediapipe:android": ["resource_util_android.cc"],
+-        "//mediapipe/framework:android_no_jni": ["resource_util_loonix.cc"],
 -        "//mediapipe:ios": ["resource_util_apple.cc"],
 -        "//mediapipe:macos": ["resource_util_default.cc"],
 -    }),
@@ -354,7 +355,7 @@ index a1b179a..7395bb5 100644
      hdrs = [
          "resource_util.h",
      ],
-@@ -184,19 +180,7 @@ cc_library(
+@@ -204,20 +199,7 @@ cc_library(
          "//mediapipe/framework/port:statusor",
          "//mediapipe/framework/port:file_helpers",
          "@com_google_absl//absl/strings",
@@ -366,6 +367,7 @@ index a1b179a..7395bb5 100644
 -            "//mediapipe/util/android:asset_manager_util",
 -            "//mediapipe/util/android/file/base",
 -        ],
+-        "//mediapipe/framework:android_no_jni": [],
 -        "//mediapipe:ios": [],
 -        "//mediapipe:macos": [
 -            "@com_google_absl//absl/flags:flag",

--- a/third_party/mediapipe_visibility.diff
+++ b/third_party/mediapipe_visibility.diff
@@ -13,12 +13,12 @@ index ed6a509..05e3336 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/calculators/core/BUILD b/mediapipe/calculators/core/BUILD
-index 61d907d..bb2a304 100644
+index ff0a5d6..b19961c 100644
 --- a/mediapipe/calculators/core/BUILD
 +++ b/mediapipe/calculators/core/BUILD
-@@ -1255,3 +1255,9 @@ cc_test(
-         "@com_google_absl//absl/time",
+@@ -1291,3 +1291,9 @@ cc_library(
      ],
+     alwayslink = 1,
  )
 +
 +filegroup(
@@ -27,10 +27,10 @@ index 61d907d..bb2a304 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/calculators/image/BUILD b/mediapipe/calculators/image/BUILD
-index 0bbfadd..bf92f47 100644
+index 5428f98..b3795d2 100644
 --- a/mediapipe/calculators/image/BUILD
 +++ b/mediapipe/calculators/image/BUILD
-@@ -796,3 +796,9 @@ cc_test(
+@@ -799,3 +799,9 @@ cc_test(
          "@com_google_absl//absl/strings",
      ],
  )
@@ -41,10 +41,10 @@ index 0bbfadd..bf92f47 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/calculators/tensor/BUILD b/mediapipe/calculators/tensor/BUILD
-index 72c2f51..f400da5 100644
+index 586fb0d..964b5d9 100644
 --- a/mediapipe/calculators/tensor/BUILD
 +++ b/mediapipe/calculators/tensor/BUILD
-@@ -886,3 +886,9 @@ cc_library(
+@@ -893,3 +893,9 @@ cc_library(
      }),
      alwayslink = 1,
  )
@@ -55,10 +55,10 @@ index 72c2f51..f400da5 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/calculators/tflite/BUILD b/mediapipe/calculators/tflite/BUILD
-index 55616bb..29cd3d4 100644
+index b132db0..3b6cb96 100644
 --- a/mediapipe/calculators/tflite/BUILD
 +++ b/mediapipe/calculators/tflite/BUILD
-@@ -566,3 +566,9 @@ cc_test(
+@@ -567,3 +567,9 @@ cc_test(
          "@org_tensorflow//tensorflow/lite:framework",
      ],
  )
@@ -69,10 +69,10 @@ index 55616bb..29cd3d4 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/calculators/util/BUILD b/mediapipe/calculators/util/BUILD
-index 0c1a3ce..13b887a 100644
+index d00fd09..37e9aa7 100644
 --- a/mediapipe/calculators/util/BUILD
 +++ b/mediapipe/calculators/util/BUILD
-@@ -1443,3 +1443,9 @@ cc_test(
+@@ -1479,3 +1479,9 @@ cc_test(
          "@com_google_absl//absl/strings",
      ],
  )
@@ -97,10 +97,10 @@ index 806b9f1..b3ad309 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/framework/BUILD b/mediapipe/framework/BUILD
-index ef32c6c..75f56fb 100644
+index 1166c2a..fc5582b 100644
 --- a/mediapipe/framework/BUILD
 +++ b/mediapipe/framework/BUILD
-@@ -1666,5 +1666,5 @@ cc_test(
+@@ -1684,5 +1684,5 @@ cc_test(
  filegroup(
      name = "protos_src",
      srcs = glob(["*.proto"]),
@@ -108,10 +108,10 @@ index ef32c6c..75f56fb 100644
 +    visibility = ["//visibility:public"],
  )
 diff --git a/mediapipe/framework/formats/BUILD b/mediapipe/framework/formats/BUILD
-index f79e6aa..546750c 100644
+index 2362692..75f2173 100644
 --- a/mediapipe/framework/formats/BUILD
 +++ b/mediapipe/framework/formats/BUILD
-@@ -310,7 +310,7 @@ mediapipe_register_type(
+@@ -327,7 +327,7 @@ mediapipe_register_type(
  filegroup(
      name = "protos_src",
      srcs = glob(["*.proto"]),
@@ -160,10 +160,10 @@ index 39940ac..0ed3615 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/gpu/BUILD b/mediapipe/gpu/BUILD
-index 2d163b4..20c82a2 100644
+index 8c9c433..49300c5 100644
 --- a/mediapipe/gpu/BUILD
 +++ b/mediapipe/gpu/BUILD
-@@ -1015,3 +1015,9 @@ ios_unit_test(
+@@ -1081,3 +1081,9 @@ ios_unit_test(
      ],
      deps = [":gl_ios_test_lib"],
  )
@@ -216,10 +216,10 @@ index 8f80312..e33dd19 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/java/com/google/mediapipe/components/BUILD b/mediapipe/java/com/google/mediapipe/components/BUILD
-index 4471a0c..8508be9 100644
+index a1ec175..012ae98 100644
 --- a/mediapipe/java/com/google/mediapipe/components/BUILD
 +++ b/mediapipe/java/com/google/mediapipe/components/BUILD
-@@ -81,5 +81,5 @@ android_library(
+@@ -91,5 +91,5 @@ android_library(
  filegroup(
      name = "java_src",
      srcs = glob(["*.java"]),
@@ -227,10 +227,10 @@ index 4471a0c..8508be9 100644
 +    visibility = ["//visibility:public"],
  )
 diff --git a/mediapipe/java/com/google/mediapipe/framework/BUILD b/mediapipe/java/com/google/mediapipe/framework/BUILD
-index ed1a42c..1f31735 100644
+index 7b1a891..5eed664 100644
 --- a/mediapipe/java/com/google/mediapipe/framework/BUILD
 +++ b/mediapipe/java/com/google/mediapipe/framework/BUILD
-@@ -141,5 +141,5 @@ filegroup(
+@@ -142,5 +142,5 @@ filegroup(
          ["*.java"],
          exclude = ["TypeNameRegistryFull.java"],
      ),
@@ -277,10 +277,10 @@ index c3c0919..261efe6 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/modules/objectron/calculators/BUILD b/mediapipe/modules/objectron/calculators/BUILD
-index fb75eb3..92b306d 100644
+index eeeaee5..cfe1445 100644
 --- a/mediapipe/modules/objectron/calculators/BUILD
 +++ b/mediapipe/modules/objectron/calculators/BUILD
-@@ -405,3 +405,9 @@ cc_test(
+@@ -422,3 +422,9 @@ cc_test(
          "@com_google_absl//absl/container:flat_hash_set",
      ],
  )
@@ -291,10 +291,10 @@ index fb75eb3..92b306d 100644
 +    visibility = ["//visibility:public"],
 +)
 diff --git a/mediapipe/util/BUILD b/mediapipe/util/BUILD
-index a1b179a..741f767 100644
+index 12a34a4..1364ab2 100644
 --- a/mediapipe/util/BUILD
 +++ b/mediapipe/util/BUILD
-@@ -343,3 +343,9 @@ cc_test(
+@@ -364,3 +364,9 @@ cc_test(
          "//mediapipe/framework/port:gtest_main",
      ],
  )

--- a/third_party/mediapipe_workaround.diff
+++ b/third_party/mediapipe_workaround.diff
@@ -1,39 +1,11 @@
-diff --git a/mediapipe/BUILD b/mediapipe/BUILD
-index 1171ea6..5f1994d 100644
---- a/mediapipe/BUILD
-+++ b/mediapipe/BUILD
-@@ -74,6 +74,7 @@ alias(
-     name = "macos",
-     actual = select({
-         ":macos_i386": ":macos_i386",
-+        ":macos_arm64": "macos_arm64",
-         ":macos_x86_64": ":macos_x86_64",
-         "//conditions:default": ":macos_i386",  # Arbitrarily chosen from above.
-     }),
-@@ -119,6 +120,15 @@ config_setting(
-     visibility = ["//visibility:public"],
- )
- 
-+config_setting(
-+    name = "macos_arm64",
-+    values = {
-+        "apple_platform_type": "macos",
-+        "cpu": "darwin_arm64",
-+    },
-+    visibility = ["//visibility:public"],
-+)
-+
- [
-     config_setting(
-         name = arch,
 diff --git a/mediapipe/calculators/tensor/BUILD b/mediapipe/calculators/tensor/BUILD
-index 72c2f51..79929e0 100644
+index 586fb0d..c73b29a 100644
 --- a/mediapipe/calculators/tensor/BUILD
 +++ b/mediapipe/calculators/tensor/BUILD
-@@ -92,7 +92,12 @@ cc_library(
-         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_buffer",
-         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_program",
-         "@org_tensorflow//tensorflow/lite/delegates/gpu/gl:gl_shader",
+@@ -97,7 +97,12 @@ cc_library(
+         "@org_tensorflow//tensorflow/lite:framework_stable",
+         "@org_tensorflow//tensorflow/lite/delegates/gpu:gl_delegate",
+         "@org_tensorflow//tensorflow/lite/delegates/gpu/common:shape",
 -    ],
 +    ] + select({
 +        "//mediapipe:android": [
@@ -249,7 +221,7 @@ index cbacdb7..f40cf91 100644
    float y;  // [0.0-1.0]
    float z;  // Centered around 1.0 [current_scale = z * initial_scale]
 diff --git a/mediapipe/modules/objectron/calculators/BUILD b/mediapipe/modules/objectron/calculators/BUILD
-index fb75eb3..0eee4ff 100644
+index eeeaee5..0fb68d0 100644
 --- a/mediapipe/modules/objectron/calculators/BUILD
 +++ b/mediapipe/modules/objectron/calculators/BUILD
 @@ -199,6 +199,15 @@ cc_library(
@@ -284,19 +256,3 @@ index fb75eb3..0eee4ff 100644
      deps = [
          ":annotation_cc_proto",
          ":belief_decoder_config_cc_proto",
-diff --git a/mediapipe/util/tflite/tflite_gpu_runner.cc b/mediapipe/util/tflite/tflite_gpu_runner.cc
-index 14a12db..b01ff6d 100644
---- a/mediapipe/util/tflite/tflite_gpu_runner.cc
-+++ b/mediapipe/util/tflite/tflite_gpu_runner.cc
-@@ -252,8 +252,10 @@ absl::Status TFLiteGPURunner::InitializeOpenCL(
-   MP_RETURN_IF_ERROR(cl_environment_->NewInferenceBuilder(
-       cl_options, std::move(graph_cl), builder));
- 
--#endif  // __ANDROID__
-   return absl::OkStatus();
-+#else
-+  return mediapipe::UnimplementedError("OpenCL is currently only supported on Android");
-+#endif  // __ANDROID__
- }
- 
- #ifdef __ANDROID__

--- a/third_party/tensorflow_xnnpack_emscripten_fixes.diff
+++ b/third_party/tensorflow_xnnpack_emscripten_fixes.diff
@@ -1,28 +1,33 @@
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index f7cd51cad30..00822c5cdde 100644
+index b999e94ef26..d3c48f2f23a 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -133,6 +133,7 @@ def _tf_repositories():
+@@ -135,6 +135,7 @@ def _tf_repositories():
      # LINT.IfChange
      tf_http_archive(
          name = "XNNPACK",
-+        patch_file = "//third_party:xnnpack_emscripten_fix.patch",
-         sha256 = "e3dcbb9278a44532ada93dad3b5fcd90d74bf18353d04dfa8868df8029bff693",
-         strip_prefix = "XNNPACK-0d6a1194ff36f59c79089336d7a3b446c3c6a39d",
-         urls = tf_mirror_urls("https://github.com/google/XNNPACK/archive/0d6a1194ff36f59c79089336d7a3b446c3c6a39d.zip"),
++        patch_file = ["//third_party:xnnpack_emscripten_fix.patch"],
+         sha256 = "7077e61fe8d766dd0887d53d86680e552c2275920eb8b4e21de772e9a24bca74",
+         strip_prefix = "XNNPACK-a0ec971de0dc82e0bf8784393cb8c4a56c171045",
+         urls = tf_mirror_urls("https://github.com/google/XNNPACK/archive/a0ec971de0dc82e0bf8784393cb8c4a56c171045.zip"),
 diff --git a/third_party/xnnpack_emscripten_fix.patch b/third_party/xnnpack_emscripten_fix.patch
 new file mode 100644
-index 00000000000..76cb98ff201
+index 00000000000..857d956675c
 --- /dev/null
 +++ b/third_party/xnnpack_emscripten_fix.patch
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,23 @@
 +diff --git a/BUILD.bazel b/BUILD.bazel
-+index 969ea354..4b297b59 100644
++index d8b8f2b61..2bf84146f 100644
 +--- a/BUILD.bazel
 ++++ b/BUILD.bazel
-+@@ -7772,11 +7772,11 @@ xnnpack_aggregate_library(
++@@ -8926,15 +8926,15 @@ xnnpack_aggregate_library(
 +     ],
 +     wasm_deps = [
++         ":wasm_prod_microkernels",
++-        ":asm_microkernels",
+++        # ":asm_microkernels",
++     ],
++     wasmrelaxedsimd_deps = [
 +         ":wasm_prod_microkernels",
 +-        ":asm_microkernels",
 ++        # ":asm_microkernels",


### PR DESCRIPTION
- Upgrade the MediaPipe version to v0.8.10
  - remove `GpuBuffer#GetGlTextureBuffer`
- Disable WASM-related patches temporarily
