### PR TITLE
fix: avoid drawing holistic landmarks twice

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HolisticLandmarkListAnnotationController.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/HolisticLandmarkListAnnotationController.cs
@@ -38,7 +38,6 @@ namespace Mediapipe.Unity
         leftHandLandmarkList?.Landmark,
         rightHandLandmarkList?.Landmark
       );
-      SyncNow();
     }
 
     public void DrawFaceLandmarkListLater(IList<NormalizedLandmark> faceLandmarkList)


### PR DESCRIPTION
Holistic landmarks are being drawn twice right now.

SyncNow() is already called in DrawNow() right in front of it.