### PR TITLE
chore: upgrade Node.js 12 actions

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -115,7 +115,7 @@ jobs:
           tar xvf artifacts.tar
           echo $(jq '.dependencies += {"com.unity.testtools.codecoverage":"1.1.1"}' Packages/manifest.json) > Packages/manifest.json
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: DummyProject/Library
           key: Library-DummyProject-${{ matrix.os }}-${{ matrix.unityVersion }}-v1

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -163,7 +163,7 @@ jobs:
     if: ${{ always() }}
     needs: test
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: linux-package
           failOnError: false

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -136,7 +136,7 @@ jobs:
     if: ${{ always() }}
     needs: test
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: macos-package
           failOnError: false

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -99,7 +99,7 @@ jobs:
           cd DummyProject
           tar xvf artifacts.tar
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: DummyProject/Library
           key: Library-DummyProject-${{ matrix.os }}-${{ matrix.unity.version }}-v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -228,27 +228,27 @@ jobs:
     needs:
       - package
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ inputs.packageName }}-base
           failOnError: false
 
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ inputs.packageName }}-mediapipe_android.aar
           failOnError: false
 
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ inputs.packageName }}-libmediapipe_c.dylib
           failOnError: false
 
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ inputs.packageName }}-MediaPipeUnity.framework
           failOnError: false
 
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: ${{ inputs.packageName }}-mediapipe_c.dll
           failOnError: false

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -126,7 +126,7 @@ jobs:
           cd DummyProject
           tar xvf artifacts.tar
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: DummyProject/Library
           key: Library-DummyProject-${{ matrix.os }}-${{ matrix.unity.version }}-v1

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -163,7 +163,7 @@ jobs:
     if: ${{ always() }}
     needs: test
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@v2
         with:
           name: windows-package
           failOnError: false

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           path: C:\Users\runneradmin\AppData\Local\bazelisk
           key: windows-bazelisk
-      - name: Mount bazel cache
-        uses: actions/cache@v3
-        with:
-          path: C:\_bzl
-          key: bazel-windows-2019-v1-${{ hashFiles('WORKSPACE') }}
 
       # Setup Python
       - uses: actions/setup-python@v4


### PR DESCRIPTION
- Upgrade actions/cache to v3 to suppress deprecation warnings
- Upgrade actions/delete-artifact to v2 to suppress deprecation warnings
- Stop caching C:\_bzl
   - it takes about 30 mins to upload the whole cache
   - at least, we need to find a way to force CMake to skip building OpenCV when there's a cache
