### PR TITLE
refactor!: make ResourceManager more customizable

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Util/ResourceUtil_Safe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Util/ResourceUtil_Safe.cs
@@ -12,7 +12,7 @@ namespace Mediapipe
   {
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern void mp__SetCustomGlobalResourceProvider__P(
-        [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.ResourceProvider provider);
+        [MarshalAs(UnmanagedType.FunctionPtr)] ResourceManager.NativeResourceProvider provider);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern void mp__SetCustomGlobalPathResolver__P(

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/LocalResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/LocalResourceManager.cs
@@ -5,7 +5,6 @@
 // https://opensource.org/licenses/MIT.
 
 #if UNITY_EDITOR
-using System;
 using System.Collections;
 using System.IO;
 using UnityEditor;
@@ -21,11 +20,7 @@ namespace Mediapipe.Unity
     private static readonly string _AssetPathRoot = "Packages/com.github.homuler.mediapipe/PackageResources/MediaPipe";
     private static string _CachePathRoot;
 
-    public override PathResolver pathResolver => PathToResourceAsFile;
-
-    public override ResourceProvider resourceProvider => GetResourceContents;
-
-    public LocalResourceManager(string path) : base()
+    public LocalResourceManager(string path) : base(PathToResourceAsFile, GetResourceContents)
     {
       // It's safe to update static members because at most one RsourceManager can be initialized.
       _RelativePath = path;
@@ -66,41 +61,19 @@ namespace Mediapipe.Unity
       Logger.LogVerbose(_TAG, $"{name} is saved to {destFilePath} (length={asset.bytes.Length})");
     }
 
-    [AOT.MonoPInvokeCallback(typeof(PathResolver))]
     protected static string PathToResourceAsFile(string assetPath)
     {
       var assetName = GetAssetNameFromPath(assetPath);
       return GetCachePathFor(assetName);
     }
 
-    [AOT.MonoPInvokeCallback(typeof(ResourceProvider))]
-    protected static bool GetResourceContents(string path, IntPtr dst)
+    protected static byte[] GetResourceContents(string path)
     {
       // TODO: try AsyncReadManager
-      try
-      {
-        Logger.LogDebug($"{path} is requested");
+      Logger.LogDebug($"{path} is requested");
 
-        var cachePath = PathToResourceAsFile(path);
-        if (!File.Exists(cachePath))
-        {
-          Logger.LogError(_TAG, $"{cachePath} is not found");
-          return false;
-        }
-
-        var asset = File.ReadAllBytes(cachePath);
-        using (var srcStr = new StdString(asset))
-        {
-          srcStr.Swap(new StdString(dst, false));
-        }
-
-        return true;
-      }
-      catch (Exception e)
-      {
-        Logger.LogException(e);
-        return false;
-      }
+      var cachePath = PathToResourceAsFile(path);
+      return File.ReadAllBytes(cachePath);
     }
 
     private static string GetAssetPathFor(string assetName)

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/StreamingAssetsResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/StreamingAssetsResourceManager.cs
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-using System;
 using System.Collections;
 using System.IO;
 using UnityEngine;
@@ -20,11 +19,7 @@ namespace Mediapipe.Unity
     private static string _AssetPathRoot;
     private static string _CachePathRoot;
 
-    public override PathResolver pathResolver => PathToResourceAsFile;
-
-    public override ResourceProvider resourceProvider => GetResourceContents;
-
-    public StreamingAssetsResourceManager(string path) : base()
+    public StreamingAssetsResourceManager(string path) : base(PathToResourceAsFile, GetResourceContents)
     {
       // It's safe to update static members because at most one RsourceManager can be initialized.
       _RelativePath = path;
@@ -67,41 +62,19 @@ namespace Mediapipe.Unity
       Logger.LogVerbose(_TAG, $"{sourceFilePath} is copied to {destFilePath}");
     }
 
-    [AOT.MonoPInvokeCallback(typeof(PathResolver))]
     protected static string PathToResourceAsFile(string assetPath)
     {
       var assetName = GetAssetNameFromPath(assetPath);
       return GetCachePathFor(assetName);
     }
 
-    [AOT.MonoPInvokeCallback(typeof(ResourceProvider))]
-    protected static bool GetResourceContents(string path, IntPtr dst)
+    protected static byte[] GetResourceContents(string path)
     {
       // TODO: try AsyncReadManager
-      try
-      {
-        Logger.LogDebug($"{path} is requested");
+      Logger.LogDebug($"{path} is requested");
 
-        var cachePath = PathToResourceAsFile(path);
-        if (!File.Exists(cachePath))
-        {
-          Logger.LogError(_TAG, $"{cachePath} is not found");
-          return false;
-        }
-
-        var asset = File.ReadAllBytes(cachePath);
-        using (var srcStr = new StdString(asset))
-        {
-          srcStr.Swap(new StdString(dst, false));
-        }
-
-        return true;
-      }
-      catch (Exception e)
-      {
-        Logger.LogException(e);
-        return false;
-      }
+      var cachePath = PathToResourceAsFile(path);
+      return File.ReadAllBytes(cachePath);
     }
 
     private IEnumerator CreateCacheFile(string assetName)


### PR DESCRIPTION
- hide the `StdString` implementation from developers
- When extending the `ResourceManager`, we don't need to add `AOT.MonoCallback` attributes to some methods anymore.

This PR will change the `ResourceManager.ResourceProvider` I/F so it is a breaking change.

related to #830 