### PR TITLE
ci: free up space to avoid "No space left on device" error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,6 +84,10 @@ jobs:
         run: |
           docker build --no-cache --build-arg UID=$(id -u) -t mediapipe_unity:latest . -f docker/linux/x86_64/Dockerfile.ubuntu
 
+      - name: Remove unused files to free up space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+
       - name: Build
         run: |
           docker run --rm \


### PR DESCRIPTION
`Release Packages` workflow is failing, so remove some unused files to free up space.
https://github.com/homuler/MediaPipeUnityPlugin/actions/runs/4323932116