### PR TITLE
Fix: edit-mode unit tests that require GPU support when running in env windows or OSX fail

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlCalculatorHelperTest.cs
@@ -9,6 +9,11 @@ using System;
 
 namespace Mediapipe.Tests
 {
+
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN
+  [Ignore("This test class requires enviroment to support GPU. Currently no GPU support in OSX or Windows.")]
+#endif
+
   public class GlCalculatorHelperTest
   {
     #region Constructor

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlContextTest.cs
@@ -9,6 +9,11 @@ using System;
 
 namespace Mediapipe.Tests
 {
+
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN
+  [Ignore("This test class requires enviroment to support GPU. Currently no GPU support in OSX or Windows.")]
+#endif
+
   public class GlContextTest
   {
     #region .GetCurrent

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GlTextureTest.cs
@@ -8,6 +8,11 @@ using NUnit.Framework;
 
 namespace Mediapipe.Tests
 {
+
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN
+  [Ignore("This test class requires enviroment to support GPU. Currently no GPU support in OSX or Windows.")]
+#endif
+
   public class GlTextureTest
   {
     #region Constructor

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GpuResourcesTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Gpu/GpuResourcesTest.cs
@@ -8,6 +8,11 @@ using NUnit.Framework;
 
 namespace Mediapipe.Tests
 {
+
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN
+  [Ignore("This test class requires enviroment to support GPU. Currently no GPU support in OSX or Windows.")]
+#endif
+
   public class GpuResourcesTest
   {
     #region Create


### PR DESCRIPTION
According to readme, GPU is not supported in windows or OSX.  However, there are unit tests that will run automatically when using Unity Test Runner that assume GPU is supported.  These tests will fail and can interfere with CI/CD.  

Potential fix is to simply ignore test classes in the "Tests/EditorMode/Gpu" directory when the detected environment is editor inside windows or OSX.  