### PR TITLE
fix: build iOS framework on M1

### DIFF
--- a/mediapipe_api/objc/BUILD
+++ b/mediapipe_api/objc/BUILD
@@ -32,7 +32,7 @@ ios_framework(
         "ipad",
     ],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = "12.0",
     visibility = ["//visibility:public"],
     deps = [
         ":mediapipe_c_ios",


### PR DESCRIPTION
- fix errors that occurs when building iOS Framework on M1 mac.