### PR TITLE
ci: cache built libraries for test

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -29,7 +29,7 @@ jobs:
       # Cache native libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /tmp/cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
 
       - name: Cache native libraries
         id: cache-native-libs

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -36,17 +36,20 @@ jobs:
             Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
           key: libs-ubuntu-20.04-v1-${{ hashFiles('cache_key.txt') }}
 
-      - name: Remove cache_key.txt
-        run: |
-          rm cache_key.txt
-
       # Setup build tools
       - name: Mount bazel cache
         if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         with:
           path: "~/.cache/bazel"
-          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
+          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}-${{ hashFiles('cache_key.txt') }}
+          restore-keys: |
+            bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}-
+            bazel-ubuntu-20.04-v1-
+
+      - name: Remove cache_key.txt
+        run: |
+          rm cache_key.txt
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -29,14 +29,18 @@ jobs:
       # Cache native libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > tmp/cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /tmp/cache_key.txt
 
       - name: Cache native libraries
         id: cache-native-libs
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.so
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+
+      - name: Remove cache_key.txt
+        run: |
+          rm cache_key.txt
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "~/.cache/bazel"
-          key: bazel-${{ runner.os }}-v1-${{ hashFiles('WORKSPACE') }}
+          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
 
       # Cache native libraries
       - name: Concat native library source files
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.so
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+          key: native-libs-ubuntu-20.04-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -19,12 +19,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # Setup build tools
-      - name: Mount bazel cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.cache/bazel"
-          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
+
 
       # Cache built libraries
       - name: Concat native library source files
@@ -44,6 +39,14 @@ jobs:
       - name: Remove cache_key.txt
         run: |
           rm cache_key.txt
+
+      # Setup build tools
+      - name: Mount bazel cache
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: "~/.cache/bazel"
+          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -24,27 +24,44 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "~/.cache/bazel"
-          key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
-      - name: Install GCC/G++ 8
+          key: bazel-${{ runner.os }}-v1-${{ hashFiles('WORKSPACE') }}
+
+      # Cache native libraries
+      - name: Concat native library source files
         run: |
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > tmp/cache_key.txt
+
+      - name: Cache native libraries
+        id: cache-native-libs
+        uses: actions/cache@v3
+        with:
+          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.so
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
+
+      # Setup Python
+      - uses: actions/setup-python@v4
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        run: |
+          # install GCC/G++ 8
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc-8 g++-8
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
-      - name: Install NuGet
-        run: |
+          # install NuGet
           sudo curl -o /usr/local/bin/nuget.exe https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
           bash -c 'echo -e "#!/bin/bash\nmono /usr/local/bin/nuget.exe \$@" | sudo tee -a /usr/local/bin/nuget'
           sudo chmod +x /usr/local/bin/nuget
 
-      # Setup Python
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Install NumPy
-        run: pip install --no-cache-dir --user numpy
+          # install NumPy
+          pip install --no-cache-dir --user numpy
 
       - name: Build
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         run: |
           unset ANDROID_NDK_HOME
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -26,17 +26,20 @@ jobs:
           path: "~/.cache/bazel"
           key: bazel-ubuntu-20.04-v1-${{ hashFiles('WORKSPACE') }}
 
-      # Cache native libraries
+      # Cache built libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
+          find WORKSPACE packages.config build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
 
-      - name: Cache native libraries
-        id: cache-native-libs
+      - name: Cache libraries
+        id: cache-libs
         uses: actions/cache@v3
         with:
-          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.so
-          key: native-libs-ubuntu-20.04-v1-${{ hashFiles('cache_key.txt') }}
+          path: |
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.so
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/Protobuf/*.dll
+            Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
+          key: libs-ubuntu-20.04-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -47,12 +47,12 @@ jobs:
 
       # Setup Python
       - uses: actions/setup-python@v4
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         with:
           python-version: '3.10'
 
       - name: Install dependencies
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           # install GCC/G++ 8
           sudo apt-get update
@@ -68,7 +68,7 @@ jobs:
           pip install --no-cache-dir --user numpy
 
       - name: Build
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           unset ANDROID_NDK_HOME
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -26,17 +26,20 @@ jobs:
           path: /private/var/tmp/_bazel_runner
           key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
 
-      # Cache native libraries
+      # Cache built libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
+          find WORKSPACE packages.config build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
 
-      - name: Cache native libraries
-        id: cache-native-libs
+      - name: Cache libraries
+        id: cache-libs
         uses: actions/cache@v3
         with:
-          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dylib
-          key: native-libs-macos-11-v1-${{ hashFiles('cache_key.txt') }}
+          path: |
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dylib
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/Protobuf/*.dll
+            Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
+          key: libs-macos-11-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -34,17 +34,20 @@ jobs:
             Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
           key: libs-macos-11-v1-${{ hashFiles('cache_key.txt') }}
 
-      - name: Remove cache_key.txt
-        run: |
-          rm cache_key.txt
-
       # Setup build tools
       - name: Mount bazel cache
         if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         with:
           path: /private/var/tmp/_bazel_runner
-          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
+          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}-${{ hashFiles('cache_key.txt') }}
+          restore-keys: |
+            bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}-
+            bazel-macos-11-v1-
+
+      - name: Remove cache_key.txt
+        run: |
+          rm cache_key.txt
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -29,14 +29,18 @@ jobs:
       # Cache native libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > tmp/cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /tmp/cache_key.txt
 
       - name: Cache native libraries
         id: cache-native-libs
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dylib
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+
+      - name: Remove cache_key.txt
+        run: |
+          rm cache_key.txt
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -29,7 +29,7 @@ jobs:
       # Cache native libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /tmp/cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
 
       - name: Cache native libraries
         id: cache-native-libs

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -24,16 +24,31 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /private/var/tmp/_bazel_runner
-          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
+          key: bazel-${{ runner.os }}-v1-${{ hashFiles('WORKSPACE') }}
+
+      # Cache native libraries
+      - name: Concat native library source files
+        run: |
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > tmp/cache_key.txt
+
+      - name: Cache native libraries
+        id: cache-native-libs
+        uses: actions/cache@v3
+        with:
+          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dylib
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
 
       # Setup Python
       - uses: actions/setup-python@v4
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         with:
           python-version: '3.10'
       - name: Install NumPy
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         run: pip install --no-cache-dir --user numpy
 
       - name: Build
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         run: |
           unset ANDROID_NDK_HOME
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /private/var/tmp/_bazel_runner
-          key: bazel-${{ runner.os }}-v1-${{ hashFiles('WORKSPACE') }}
+          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
 
       # Cache native libraries
       - name: Concat native library source files
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dylib
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+          key: native-libs-macos-11-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -19,13 +19,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # Setup build tools
-      - name: Mount bazel cache
-        uses: actions/cache@v3
-        with:
-          path: /private/var/tmp/_bazel_runner
-          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
-
       # Cache built libraries
       - name: Concat native library source files
         run: |
@@ -44,6 +37,14 @@ jobs:
       - name: Remove cache_key.txt
         run: |
           rm cache_key.txt
+
+      # Setup build tools
+      - name: Mount bazel cache
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: /private/var/tmp/_bazel_runner
+          key: bazel-macos-11-v1-${{ hashFiles('WORKSPACE') }}
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -47,15 +47,15 @@ jobs:
 
       # Setup Python
       - uses: actions/setup-python@v4
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         with:
           python-version: '3.10'
       - name: Install NumPy
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: pip install --no-cache-dir --user numpy
 
       - name: Build
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           unset ANDROID_NDK_HOME
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -295,7 +295,6 @@ jobs:
 
   clean:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
     needs:
       - package
     steps:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/mediapipe_c.dll
             Packages/com.github.homuler.mediapipe/Runtime/Plugins/Protobuf/*.dll
             Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
           key: libs-windows-2019-v1-${{ hashFiles('cache_key.txt') }}

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -31,14 +31,29 @@ jobs:
           path: C:\Users\runneradmin\AppData\Local\bazelisk
           key: windows-bazelisk
 
+      # Cache built libraries
+      - name: Concat native library source files
+        run: |
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /c/tmp/cache_key.txt
+
+      - name: Cache native libraries
+        id: cache-native-libs
+        uses: actions/cache@v3
+        with:
+          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
+
       # Setup Python
       - uses: actions/setup-python@v4
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         with:
           python-version: '3.10'
       - name: Install NumPy
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         run: pip install --no-cache-dir --user numpy
 
       - name: Build
+        if: steps.cache-native-libs.outputs.cache-hit != 'true'
         run: |
           set ANDROID_NDK_HOME=
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -34,15 +34,18 @@ jobs:
       # Cache built libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
+          find WORKSPACE packages.config build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
         shell: bash
 
-      - name: Cache native libraries
-        id: cache-native-libs
+      - name: Cache libraries
+        id: cache-libs
         uses: actions/cache@v3
         with:
-          path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
-          key: native-libs-windows-2019-v1-${{ hashFiles('cache_key.txt') }}
+          path: |
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
+            Packages/com.github.homuler.mediapipe/Runtime/Plugins/Protobuf/*.dll
+            Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
+          key: libs-windows-2019-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -137,6 +137,7 @@ jobs:
           mv artifacts.tar DummyProject
           cd DummyProject
           tar xvf artifacts.tar
+        timeout-minutes: 8
 
       - uses: actions/cache@v3
         with:
@@ -157,6 +158,7 @@ jobs:
             -testPlatform EditMode `
             -testCategory !GpuOnly;!SignalAbort"
           exit $process.ExitCode
+        timeout-minutes: 3
 
       - name: Cat results.xml
         env:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+          key: native-libs-windows-2019-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -34,7 +34,7 @@ jobs:
       # Cache built libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
         shell: cmd
 
       - name: Cache native libraries

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -102,6 +102,7 @@ jobs:
         run: |
           Start-Process -NoNewWindow -Wait -PassThru "C:\Program Files\Unity\Hub\Editor\${{ matrix.unity.version }}\Editor\Unity.exe" -ArgumentList "-quit -batchmode -createManualActivationFile -logfile"
           exit 0
+        timeout-minutes: 1
       - name: Request a Unity license file
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -54,15 +54,15 @@ jobs:
 
       # Setup Python
       - uses: actions/setup-python@v4
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         with:
           python-version: '3.10'
       - name: Install NumPy
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: pip install --no-cache-dir --user numpy
 
       - name: Build
-        if: steps.cache-native-libs.outputs.cache-hit != 'true'
+        if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           set ANDROID_NDK_HOME=
           python build.py build --desktop cpu --opencv cmake -vv

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -19,18 +19,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # Setup build tools
-      - uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          update: true
-          install: git patch unzip zip
-      - name: Mount bazelisk cache
-        uses: actions/cache@v3
-        with:
-          path: C:\Users\runneradmin\AppData\Local\bazelisk
-          key: windows-bazelisk
-
       # Cache built libraries
       - name: Concat native library source files
         run: |
@@ -51,6 +39,14 @@ jobs:
         run: |
           rm cache_key.txt
         shell: cmd
+
+      # Setup build tools
+      - uses: msys2/setup-msys2@v2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        with:
+          msystem: MINGW64
+          update: true
+          install: git patch unzip zip
 
       # Setup Python
       - uses: actions/setup-python@v4
@@ -79,10 +75,6 @@ jobs:
           name: windows-package
           path: artifacts.tar
           retention-days: 1
-
-      - name: Prepare for cache
-        run: |
-          (Get-Item C:\_bzl\*\install).Delete()
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -34,14 +34,20 @@ jobs:
       # Cache built libraries
       - name: Concat native library source files
         run: |
-          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > /c/tmp/cache_key.txt
+          find WORKSPACE build.py mediapipe_api/ third_party/ | sort | xargs cat > cache_key.txt
+        shell: cmd
 
       - name: Cache native libraries
         id: cache-native-libs
         uses: actions/cache@v3
         with:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/libmediapipe_c.dll
-          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('tmp/cache_key.txt') }}
+          key: native-libs-${{ runner.os }}-v1-${{ hashFiles('cache_key.txt') }}
+
+      - name: Remove cache_key.txt
+        run: |
+          rm cache_key.txt
+        shell: cmd
 
       # Setup Python
       - uses: actions/setup-python@v4

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Concat native library source files
         run: |
           find WORKSPACE build.py mediapipe_api/ third_party/ -type f | sort | xargs cat > cache_key.txt
-        shell: cmd
+        shell: bash
 
       - name: Cache native libraries
         id: cache-native-libs


### PR DESCRIPTION
Currently, it takes more than 1 hour to test on Windows.
This PR aims to reduce the time taken by CI by caching the built libraries.
