### PR TITLE
Fix: proper size for an image using AutoFit if camera is rotated

### DIFF
--- a/Assets/MediaPipeUnity/Samples/UI/Scripts/AutoFit.cs
+++ b/Assets/MediaPipeUnity/Samples/UI/Scripts/AutoFit.cs
@@ -54,8 +54,8 @@ namespace Mediapipe.Unity
       var center = rect.center;
       var topLeftRel = new Vector2(rect.xMin - center.x, rect.yMin - center.y);
       var topRightRel = new Vector2(rect.xMax - center.x, rect.yMin - center.y);
-      var rotatedTopLeftRel = rectTransform.rotation * topLeftRel;
-      var rotatedTopRightRel = rectTransform.rotation * topRightRel;
+      var rotatedTopLeftRel = rectTransform.localRotation * topLeftRel;
+      var rotatedTopRightRel = rectTransform.localRotation * topRightRel;
       var wMax = Mathf.Max(Mathf.Abs(rotatedTopLeftRel.x), Mathf.Abs(rotatedTopRightRel.x));
       var hMax = Mathf.Max(Mathf.Abs(rotatedTopLeftRel.y), Mathf.Abs(rotatedTopRightRel.y));
       return (2 * wMax, 2 * hMax);


### PR DESCRIPTION
If the camera is rotated, for example, by the Z axis, the size of the image is incorrectly adjusted because we are taking the global rotation of an image in `GetBoundingBoxSize(...)`. This effect is very noticeable when using a camera image from ARCoreCamera and applying it to RawImage in Canvas.

### Preview of the issue:

![Preview of the issue](https://github.com/homuler/MediaPipeUnityPlugin/assets/20156133/c4e5b876-6243-4a3a-bca7-260b1a7a7673)
