### PR TITLE
fix: switch between the back camera and front camera

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Common/Scripts/ImageSource/WebCamSource.cs
+++ b/Assets/MediaPipeUnity/Samples/Common/Scripts/ImageSource/WebCamSource.cs
@@ -123,6 +123,11 @@ namespace Mediapipe.Unity
         yield break;
       }
 
+      if (webCamDevice != null)
+      {
+        yield break;
+      }
+
       availableSources = WebCamTexture.devices;
 
       if (availableSources != null && availableSources.Length > 0)


### PR DESCRIPTION
After the `webCamDevice` is selected, it is always reset to the first `WebCamTexture.devices` when `Play()` is called.

introduced by #1017.