### PR TITLE
feat: implement non-generic Packet class (bool/bool vector)

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/External/StructArray.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/External/StructArray.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Mediapipe
+{
+  [StructLayout(LayoutKind.Sequential)]
+  internal readonly struct StructArray
+  {
+    private readonly IntPtr _data;
+    private readonly int _size;
+
+    public void Dispose()
+    {
+      UnsafeNativeMethods.delete_array__Pf(_data);
+    }
+
+    public List<T> Copy<T>() where T : unmanaged
+    {
+      var data = new List<T>(_size);
+
+      CopyTo(data);
+      return data;
+    }
+
+    public void CopyTo<T>(List<T> data) where T : unmanaged
+    {
+      data.Clear();
+
+      unsafe
+      {
+        var ptr = (T*)_data;
+
+        for (var i = 0; i < _size; i++)
+        {
+          data.Add(*ptr++);
+        }
+      }
+    }
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/External/StructArray.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/External/StructArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8ce195f36f8b3d2cab3e50f079b6507
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 using System;
+using System.Collections.Generic;
 
 namespace Mediapipe
 {
@@ -43,6 +44,9 @@ namespace Mediapipe
     /// </param>
     public static Packet CreateForReference(IntPtr ptr) => new Packet(ptr, false);
 
+    /// <summary>
+    ///   Create a bool Packet from a boolean.
+    /// </summary>
     public static Packet CreateBool(bool value)
     {
       UnsafeNativeMethods.mp__MakeBoolPacket__b(value, out var ptr).Assert();
@@ -50,9 +54,38 @@ namespace Mediapipe
       return new Packet(ptr, true);
     }
 
+    /// <summary>
+    ///   Create a bool Packet.
+    /// </summary>
+    /// <param name="timestampMicrosec">
+    ///   The timestamp of the packet.
+    /// </param>
     public static Packet CreateBoolAt(bool value, long timestampMicrosec)
     {
       UnsafeNativeMethods.mp__MakeBoolPacket_At__b_ll(value, timestampMicrosec, out var ptr).Assert();
+
+      return new Packet(ptr, true);
+    }
+
+    /// <summary>
+    ///   Create a bool vector Packet.
+    /// </summary>
+    public static Packet CreateBoolVector(bool[] value)
+    {
+      UnsafeNativeMethods.mp__MakeBoolVectorPacket__Pb_i(value, value.Length, out var ptr).Assert();
+
+      return new Packet(ptr, true);
+    }
+
+    /// <summary>
+    ///   Create a bool vector Packet.
+    /// </summary>
+    /// <param name="timestampMicrosec">
+    ///   The timestamp of the packet.
+    /// </param>
+    public static Packet CreateBoolVectorAt(bool[] value, long timestampMicrosec)
+    {
+      UnsafeNativeMethods.mp__MakeBoolVectorPacket_At__Pb_i_ll(value, value.Length, timestampMicrosec, out var ptr).Assert();
 
       return new Packet(ptr, true);
     }
@@ -75,6 +108,32 @@ namespace Mediapipe
     }
 
     /// <summary>
+    ///   Get the content of a bool vector Packet as a <see cref="List{bool}"/>.
+    /// </summary>
+    public List<bool> GetBoolList()
+    {
+      var value = new List<bool>();
+      GetBoolList(value);
+
+      return value;
+    }
+
+    /// <summary>
+    ///   Get the content of a bool vector Packet as a <see cref="List{bool}"/>.
+    /// </summary>
+    /// <param name="value">
+    ///   The <see cref="List{bool}"/> to be filled with the content of the <see cref="Packet"/>.
+    /// </param>
+    public void GetBoolList(List<bool> value)
+    {
+      UnsafeNativeMethods.mp_Packet__GetBoolVector(mpPtr, out var structArray).Assert();
+      GC.KeepAlive(this);
+
+      structArray.CopyTo(value);
+      structArray.Dispose();
+    }
+
+    /// <summary>
     ///   Validate if the content of the <see cref="Packet"/> is a boolean.
     /// </summary>
     /// <exception cref="BadStatusException">
@@ -83,6 +142,20 @@ namespace Mediapipe
     public void ValidateAsBool()
     {
       UnsafeNativeMethods.mp_Packet__ValidateAsBool(mpPtr, out var statusPtr).Assert();
+
+      GC.KeepAlive(this);
+      AssertStatusOk(statusPtr);
+    }
+
+    /// <summary>
+    ///   Validate if the content of the <see cref="Packet"/> is a std::vector&lt;bool&gt;.
+    /// </summary>
+    /// <exception cref="BadStatusException">
+    ///   If the <see cref="Packet"/> doesn't contain std::vector&lt;bool&gt;.
+    /// </exception>
+    public void ValidateAsBoolVector()
+    {
+      UnsafeNativeMethods.mp_Packet__ValidateAsBoolVector(mpPtr, out var statusPtr).Assert();
 
       GC.KeepAlive(this);
       AssertStatusOk(statusPtr);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2023 homuler
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+using System;
+
+namespace Mediapipe
+{
+  public class Packet : MpResourceHandle
+  {
+    private Packet(IntPtr ptr, bool isOwner) : base(ptr, isOwner) { }
+
+    protected override void DeleteMpPtr()
+    {
+      UnsafeNativeMethods.mp_Packet__delete(ptr);
+    }
+
+    public long TimestampMicroseconds()
+    {
+      var value = SafeNativeMethods.mp_Packet__TimestampMicroseconds(mpPtr);
+      GC.KeepAlive(this);
+
+      return value;
+    }
+
+    internal static Packet CreateEmpty()
+    {
+      UnsafeNativeMethods.mp_Packet__(out var ptr).Assert();
+
+      return new Packet(ptr, true);
+    }
+
+    /// <summary>
+    ///   Low-level API to reference the packet that <paramref name="ptr" /> points to.
+    /// </summary>
+    /// <remarks>
+    ///   This method is to be used when you want to reference the packet whose lifetime is managed by native code.
+    /// </remarks>
+    /// <param name="ptr">
+    ///   A pointer to a native Packet instance.
+    /// </param>
+    public static Packet CreateForReference(IntPtr ptr) => new Packet(ptr, false);
+
+    public static Packet CreateBool(bool value)
+    {
+      UnsafeNativeMethods.mp__MakeBoolPacket__b(value, out var ptr).Assert();
+
+      return new Packet(ptr, true);
+    }
+
+    public static Packet CreateBoolAt(bool value, long timestampMicrosec)
+    {
+      UnsafeNativeMethods.mp__MakeBoolPacket_At__b_ll(value, timestampMicrosec, out var ptr).Assert();
+
+      return new Packet(ptr, true);
+    }
+
+    /// <summary>
+    ///   Get the content of the <see cref="Packet"/> as a boolean.
+    /// </summary>
+    /// <remarks>
+    ///   On some platforms (e.g. Windows), it will abort the process when <see cref="MediaPipeException"/> should be thrown. 
+    /// </remarks>
+    /// <exception cref="MediaPipeException">
+    ///   If the <see cref="Packet"/> doesn't contain bool data.
+    /// </exception>
+    public bool GetBool()
+    {
+      UnsafeNativeMethods.mp_Packet__GetBool(mpPtr, out var value).Assert();
+
+      GC.KeepAlive(this);
+      return value;
+    }
+
+    /// <summary>
+    ///   Validate if the content of the <see cref="Packet"/> is a boolean.
+    /// </summary>
+    /// <exception cref="BadStatusException">
+    ///   If the <see cref="Packet"/> doesn't contain bool data.
+    /// </exception>
+    public void ValidateAsBool()
+    {
+      UnsafeNativeMethods.mp_Packet__ValidateAsBool(mpPtr, out var statusPtr).Assert();
+
+      GC.KeepAlive(this);
+      AssertStatusOk(statusPtr);
+    }
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Framework/Packet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 924c050535511bec3a144d0d3d42d4bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Safe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Safe.cs
@@ -17,6 +17,9 @@ namespace Mediapipe
     public static extern bool mp_Packet__IsEmpty(IntPtr packet);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern long mp_Packet__TimestampMicroseconds(IntPtr packet);
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern void mp_PacketMap__clear(IntPtr packetMap);
 
     [Pure, DllImport(MediaPipeLibrary, ExactSpelling = true)]

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Unsafe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Unsafe.cs
@@ -54,6 +54,20 @@ namespace Mediapipe
     public static extern MpReturnCode mp_Packet__ValidateAsBool(IntPtr packet, out IntPtr status);
     #endregion
 
+    #region BoolVector
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern MpReturnCode mp__MakeBoolVectorPacket__Pb_i(bool[] value, int size, out IntPtr packet);
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern MpReturnCode mp__MakeBoolVectorPacket_At__Pb_i_ll(bool[] value, int size, long timestampMicrosec, out IntPtr packet);
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern MpReturnCode mp_Packet__GetBoolVector(IntPtr packet, out StructArray value);
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern MpReturnCode mp_Packet__ValidateAsBoolVector(IntPtr packet, out IntPtr status);
+    #endregion
+
     #region Float
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern MpReturnCode mp__MakeFloatPacket__f(float value, out IntPtr packet);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Unsafe.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/PInvoke/NativeMethods/Framework/Packet_Unsafe.cs
@@ -45,6 +45,9 @@ namespace Mediapipe
     public static extern MpReturnCode mp__MakeBoolPacket_At__b_Rt([MarshalAs(UnmanagedType.I1)] bool value, IntPtr timestamp, out IntPtr packet);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]
+    public static extern MpReturnCode mp__MakeBoolPacket_At__b_ll([MarshalAs(UnmanagedType.I1)] bool value, long timestampMicrosec, out IntPtr packet);
+
+    [DllImport(MediaPipeLibrary, ExactSpelling = true)]
     public static extern MpReturnCode mp_Packet__GetBool(IntPtr packet, [MarshalAs(UnmanagedType.I1)] out bool value);
 
     [DllImport(MediaPipeLibrary, ExactSpelling = true)]

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/Packet/PacketTest.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace Mediapipe.Tests
 {
-  public class PacketTest
+  public class GenericPacketTest
   {
     #region #DebugString
     [Test]

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs
@@ -37,12 +37,58 @@ namespace Mediapipe.Tests
     }
     #endregion
 
+    #region BoolVector
+    [Test]
+    public void CreateBoolVector_ShouldReturnNewBoolVectorPacket()
+    {
+      var value = new bool[] { true, false };
+      using var packet = Packet.CreateBoolVector(value);
+
+      Assert.DoesNotThrow(packet.ValidateAsBoolVector);
+
+      var result = packet.GetBoolList();
+      Assert.AreEqual(value.Length, result.Count);
+      for (var i = 0; i < value.Length; i++)
+      {
+        Assert.AreEqual(value[i], result[i]);
+      }
+
+      using var unsetTimestamp = Timestamp.Unset();
+      Assert.AreEqual(unsetTimestamp.Microseconds(), packet.TimestampMicroseconds());
+    }
+
+    [Test]
+    public void CreateBoolVectorAt_ShouldReturnNewBoolVectorPacket()
+    {
+      var value = new bool[] { true, false };
+      var timestamp = 1;
+      using var packet = Packet.CreateBoolVectorAt(value, timestamp);
+
+      Assert.DoesNotThrow(packet.ValidateAsBoolVector);
+
+      var result = packet.GetBoolList();
+      Assert.AreEqual(value.Length, result.Count);
+      for (var i = 0; i < value.Length; i++)
+      {
+        Assert.AreEqual(value[i], result[i]);
+      }
+      Assert.AreEqual(timestamp, packet.TimestampMicroseconds());
+    }
+    #endregion
+
     #region #Validate
     [Test]
     public void ValidateAsBool_ShouldThrow_When_ValueIsNotSet()
     {
       using var packet = Packet.CreateEmpty();
       _ = Assert.Throws<BadStatusException>(packet.ValidateAsBool);
+    }
+
+    [Test]
+    public void ValidateAsBoolVector_ShouldThrow_When_ValueIsNotSet()
+    {
+      using var packet = Packet.CreateEmpty();
+      _ = Assert.Throws<BadStatusException>(packet.ValidateAsBoolVector);
     }
     #endregion
   }

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 homuler
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+using NUnit.Framework;
+
+namespace Mediapipe.Tests
+{
+  public class PacketTest
+  {
+    #region Bool
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CreateBool_ShouldReturnNewBoolPacket(bool value)
+    {
+      using var packet = Packet.CreateBool(value);
+
+      Assert.DoesNotThrow(packet.ValidateAsBool);
+      Assert.AreEqual(value, packet.GetBool());
+
+      using var unsetTimestamp = Timestamp.Unset();
+      Assert.AreEqual(unsetTimestamp.Microseconds(), packet.TimestampMicroseconds());
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CreateBoolAt_ShouldReturnNewBoolPacket(bool value)
+    {
+      var timestamp = 1;
+      using var packet = Packet.CreateBoolAt(value, timestamp);
+
+      Assert.DoesNotThrow(packet.ValidateAsBool);
+      Assert.AreEqual(value, packet.GetBool());
+      Assert.AreEqual(timestamp, packet.TimestampMicroseconds());
+    }
+    #endregion
+
+    #region #Validate
+    [Test]
+    public void ValidateAsBool_ShouldThrow_When_ValueIsNotSet()
+    {
+      using var packet = Packet.CreateEmpty();
+      _ = Assert.Throws<BadStatusException>(packet.ValidateAsBool);
+    }
+    #endregion
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Tests/EditMode/Framework/PacketTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6d8bfae145dc40a5a2a4d0749f69c00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/mediapipe_api/framework/packet.cc
+++ b/mediapipe_api/framework/packet.cc
@@ -42,6 +42,10 @@ MpReturnCode mp_Packet__Timestamp(mediapipe::Packet* packet, mediapipe::Timestam
   CATCH_EXCEPTION
 }
 
+int64 mp_Packet__TimestampMicroseconds(mediapipe::Packet* packet) {
+  return packet->Timestamp().Microseconds();
+}
+
 MpReturnCode mp_Packet__DebugString(mediapipe::Packet* packet, const char** str_out) {
   TRY
     *str_out = strcpy_to_heap(packet->DebugString());
@@ -74,6 +78,13 @@ MpReturnCode mp__MakeBoolPacket__b(bool value, mediapipe::Packet** packet_out) {
 MpReturnCode mp__MakeBoolPacket_At__b_Rt(bool value, mediapipe::Timestamp* timestamp, mediapipe::Packet** packet_out) {
   TRY
     *packet_out = new mediapipe::Packet{mediapipe::MakePacket<bool>(value).At(*timestamp)};
+    RETURN_CODE(MpReturnCode::Success);
+  CATCH_EXCEPTION
+}
+
+MpReturnCode mp__MakeBoolPacket_At__b_ll(bool value, int64 timestampMicrosec, mediapipe::Packet** packet_out) {
+  TRY
+    *packet_out = new mediapipe::Packet{mediapipe::MakePacket<bool>(value).At(mediapipe::Timestamp(timestampMicrosec))};
     RETURN_CODE(MpReturnCode::Success);
   CATCH_EXCEPTION
 }

--- a/mediapipe_api/framework/packet.cc
+++ b/mediapipe_api/framework/packet.cc
@@ -103,6 +103,26 @@ MpReturnCode mp_Packet__ValidateAsBool(mediapipe::Packet* packet, absl::Status**
   CATCH_EXCEPTION
 }
 
+// BoolVectorPacket
+MpReturnCode mp__MakeBoolVectorPacket__Pb_i(bool* value, int size, mediapipe::Packet** packet_out) {
+  return mp__MakeVectorPacket(value, size, packet_out);
+}
+
+MpReturnCode mp__MakeBoolVectorPacket_At__Pb_i_ll(bool* value, int size, int64 timestampMicrosec, mediapipe::Packet** packet_out) {
+  return mp__MakeVectorPacket_At(value, size, timestampMicrosec, packet_out);
+}
+
+MpReturnCode mp_Packet__GetBoolVector(mediapipe::Packet* packet, mp_api::StructArray<bool>* value_out) {
+  return mp_Packet__GetStructVector(packet, value_out);
+}
+
+MpReturnCode mp_Packet__ValidateAsBoolVector(mediapipe::Packet* packet, absl::Status** status_out) {
+  TRY
+    *status_out = new absl::Status{packet->ValidateAsType<std::vector<bool>>()};
+    RETURN_CODE(MpReturnCode::Success);
+  CATCH_EXCEPTION
+}
+
 // FloatPacket
 MpReturnCode mp__MakeFloatPacket__f(float value, mediapipe::Packet** packet_out) {
   TRY

--- a/mediapipe_api/framework/packet.h
+++ b/mediapipe_api/framework/packet.h
@@ -52,6 +52,12 @@ MP_CAPI(MpReturnCode) mp__MakeBoolPacket_At__b_ll(bool value, int64 timestampMic
 MP_CAPI(MpReturnCode) mp_Packet__GetBool(mediapipe::Packet* packet, bool* value_out);
 MP_CAPI(MpReturnCode) mp_Packet__ValidateAsBool(mediapipe::Packet* packet, absl::Status** status_out);
 
+// std::vector<bool>
+MP_CAPI(MpReturnCode) mp__MakeBoolVectorPacket__Pb_i(bool* value, int size, mediapipe::Packet** packet_out);
+MP_CAPI(MpReturnCode) mp__MakeBoolVectorPacket_At__Pb_i_ll(bool* value, int size, int64 timestampMicrosec, mediapipe::Packet** packet_out);
+MP_CAPI(MpReturnCode) mp_Packet__GetBoolVector(mediapipe::Packet* packet, mp_api::StructArray<bool>* value_out);
+MP_CAPI(MpReturnCode) mp_Packet__ValidateAsBoolVector(mediapipe::Packet* packet, absl::Status** status_out);
+
 // float
 MP_CAPI(MpReturnCode) mp__MakeFloatPacket__f(float value, mediapipe::Packet** packet_out);
 MP_CAPI(MpReturnCode) mp__MakeFloatPacket_At__f_Rt(float value, mediapipe::Timestamp* timestamp, mediapipe::Packet** packet_out);
@@ -142,6 +148,15 @@ inline MpReturnCode mp__MakeVectorPacket_At(const T* array, int size, mediapipe:
   TRY
     std::vector<T> vector(array, array + size);
     *packet_out = new mediapipe::Packet{mediapipe::MakePacket<std::vector<T>>(vector).At(*timestamp)};
+    RETURN_CODE(MpReturnCode::Success);
+  CATCH_EXCEPTION
+}
+
+template <typename T>
+inline MpReturnCode mp__MakeVectorPacket_At(const T* array, int size, int64 timestampMicrosec, mediapipe::Packet** packet_out) {
+  TRY
+    std::vector<T> vector(array, array + size);
+    *packet_out = new mediapipe::Packet{mediapipe::MakePacket<std::vector<T>>(vector).At(mediapipe::Timestamp(timestampMicrosec))};
     RETURN_CODE(MpReturnCode::Success);
   CATCH_EXCEPTION
 }

--- a/mediapipe_api/framework/packet.h
+++ b/mediapipe_api/framework/packet.h
@@ -40,6 +40,7 @@ MP_CAPI(MpReturnCode) mp_Packet__At__Rt(mediapipe::Packet* packet, mediapipe::Ti
 MP_CAPI(bool) mp_Packet__IsEmpty(mediapipe::Packet* packet);
 MP_CAPI(MpReturnCode) mp_Packet__ValidateAsProtoMessageLite(mediapipe::Packet* packet, absl::Status** status_out);
 MP_CAPI(MpReturnCode) mp_Packet__Timestamp(mediapipe::Packet* packet, mediapipe::Timestamp** timestamp_out);
+MP_CAPI(int64) mp_Packet__TimestampMicroseconds(mediapipe::Packet* packet);
 MP_CAPI(MpReturnCode) mp_Packet__DebugString(mediapipe::Packet* packet, const char** str_out);
 MP_CAPI(MpReturnCode) mp_Packet__RegisteredTypeName(mediapipe::Packet* packet, const char** str_out);
 MP_CAPI(MpReturnCode) mp_Packet__DebugTypeName(mediapipe::Packet* packet, const char** str_out);
@@ -47,6 +48,7 @@ MP_CAPI(MpReturnCode) mp_Packet__DebugTypeName(mediapipe::Packet* packet, const 
 // bool
 MP_CAPI(MpReturnCode) mp__MakeBoolPacket__b(bool value, mediapipe::Packet** packet_out);
 MP_CAPI(MpReturnCode) mp__MakeBoolPacket_At__b_Rt(bool value, mediapipe::Timestamp* timestamp, mediapipe::Packet** packet_out);
+MP_CAPI(MpReturnCode) mp__MakeBoolPacket_At__b_ll(bool value, int64 timestampMicrosec, mediapipe::Packet** packet_out);
 MP_CAPI(MpReturnCode) mp_Packet__GetBool(mediapipe::Packet* packet, bool* value_out);
 MP_CAPI(MpReturnCode) mp_Packet__ValidateAsBool(mediapipe::Packet* packet, absl::Status** status_out);
 


### PR DESCRIPTION
Migrating from generic Packet class to non-generic Packet class.

The non-generic Packet class will implement `packet_creator` and `packet_getter` APIs.
cf. https://developers.google.com/mediapipe/api/solutions/python/mp/packet_creator, https://developers.google.com/mediapipe/api/solutions/python/mp/packet_getter