### PR TITLE
feat(sample): drop non-blocking sync mode

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Common/Scripts/RunningMode.cs
+++ b/Assets/MediaPipeUnity/Samples/Common/Scripts/RunningMode.cs
@@ -10,7 +10,6 @@ namespace Mediapipe.Unity
   public enum RunningMode
   {
     Async,
-    NonBlockingSync,
     Sync,
   }
 
@@ -18,7 +17,7 @@ namespace Mediapipe.Unity
   {
     public static bool IsSynchronous(this RunningMode runningMode)
     {
-      return runningMode == RunningMode.Sync || runningMode == RunningMode.NonBlockingSync;
+      return runningMode == RunningMode.Sync;
     }
   }
 }


### PR DESCRIPTION
Drop non-blocking sync mode, since the current sync mode doesn't block the main thread thanks to the new `OutputStream.WaitNextSync` API.