### PR TITLE
fix: build audio classifier for armv7

### DIFF
--- a/mediapipe_api/BUILD
+++ b/mediapipe_api/BUILD
@@ -448,6 +448,10 @@ cc_library(
 cc_library(
     name = "audio_classification_calculators",
     deps = ["@mediapipe//mediapipe/tasks/cc/audio/audio_classifier:audio_classifier"],
+    copts = select({
+        "@platforms//cpu:armv7": ["-mfpu=neon"], # NEON must be enabled for pffft
+        "//conditions:default": [],
+    }),
 )
 
 pkg_zip(


### PR DESCRIPTION
fix the build error.
https://github.com/homuler/MediaPipeUnityPlugin/actions/runs/7725698637