### PR TITLE
build: remove the fat option and add x86/x86_64 options for android

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,10 +57,13 @@ build:android_arm64 --config=android
 build:android_arm64 --cpu=arm64-v8a
 build:android_arm64 --fat_apk_cpu=arm64-v8a
 
-build:android_fat --config=android
-# specify dummy cpu to avoid an error: "Illegal ambiguous match on configurable attribute "linkopts" in @XNNPACK//:xnnpack_for_tflite:"
-build:android_fat --cpu=arm64-v8a
-build:android_fat --fat_apk_cpu=armeabi-v7a,arm64-v8a
+build:android_x86 --config=android
+build:android_x86 --cpu=x86
+build:android_x86 --fat_apk_cpu=x86
+
+build:android_x86_64 --config=android
+build:android_x86_64 --cpu=x86_64
+build:android_x86_64 --fat_apk_cpu=x86_64
 
 build:ios --apple_platform_type=ios
 build:ios --copt=-fno-aligned-allocation

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -30,7 +30,7 @@ jobs:
       packageName: package
       bazelBuildArgs: ${{ inputs.bazelBuildArgs || '--experimental_scale_timeouts=10.0 --http_timeout_scaling=10.0' }}
       linuxBuildArgs: ${{ inputs.linuxBuildArgs || '--desktop gpu --opencv cmake' }}
-      androidBuildArgs: ${{ inputs.androidBuildArgs || '--android fat --android_ndk_api_level 21' }}
+      androidBuildArgs: ${{ inputs.androidBuildArgs || '--android arm64 --android_ndk_api_level 21' }}
       macosBuildArgs: ${{ inputs.macosBuildArgs || '--desktop cpu --opencv cmake --macos_universal' }}
       iosBuildArgs: ${{ inputs.iosBuildArgs || '--ios arm64' }}
       windowsBuildArgs: ${{ inputs.windowsBuildArgs || '--desktop cpu --opencv cmake' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ on:
         default: '--desktop gpu --opencv cmake'
       androidBuildArgs:
         type: string
-        default: '--android fat --android_ndk_api_level 21'
+        default: '--android arm64 --android_ndk_api_level 21'
       macosBuildArgs:
         type: string
         default: '--desktop cpu --opencv cmake --macos_universal'

--- a/build.py
+++ b/build.py
@@ -424,7 +424,7 @@ class Argument:
 
     build_command_parser = subparsers.add_parser('build', help='Build and install native libraries')
     build_command_parser.add_argument('--desktop', choices=['cpu', 'gpu'])
-    build_command_parser.add_argument('--android', choices=['armv7', 'arm64', 'fat'])
+    build_command_parser.add_argument('--android', choices=['armv7', 'arm64', 'x86', 'x86_64'])
     build_command_parser.add_argument('--android_ndk_api_level', type=int, choices=range(16, 31))
     build_command_parser.add_argument('--ios', choices=['arm64'])
     build_command_parser.add_argument('--resources', action=argparse.BooleanOptionalAction, default=True)

--- a/build.py
+++ b/build.py
@@ -285,6 +285,10 @@ class BuildCommand(Command):
 
     commands = self._build_common_commands()
     commands.append(f'--config=android_{self.command_args.android}')
+
+    if self.command_args.android_fat_apk_cpu is not None:
+      commands.append(f'--fat_apk_cpu={",".join(self.command_args.android_fat_apk_cpu)}')
+
     commands.append('//mediapipe_api/java/com/github/homuler/mediapipe:mediapipe_android')
     return commands
 
@@ -425,6 +429,7 @@ class Argument:
     build_command_parser = subparsers.add_parser('build', help='Build and install native libraries')
     build_command_parser.add_argument('--desktop', choices=['cpu', 'gpu'])
     build_command_parser.add_argument('--android', choices=['armv7', 'arm64', 'x86', 'x86_64'])
+    build_command_parser.add_argument('--android_fat_apk_cpu', nargs='+')
     build_command_parser.add_argument('--android_ndk_api_level', type=int, choices=range(16, 31))
     build_command_parser.add_argument('--ios', choices=['arm64'])
     build_command_parser.add_argument('--resources', action=argparse.BooleanOptionalAction, default=True)


### PR DESCRIPTION
`--fat_apk_cpu` option is not working as intended (e.g. `-march` option is decided only by `--cpu`) so remove the `fat` option temporarily.
