### PR TITLE
ci: build the aar for arm64 only

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,7 +12,7 @@ jobs:
       ref: ${{ github.event.ref }}
       packageName: package-for-development
       linuxBuildArgs: '--desktop gpu --opencv cmake'
-      androidBuildArgs: '--android fat --android_ndk_api_level 21'
+      androidBuildArgs: '--android arm64 --android_ndk_api_level 21'
       macosBuildArgs: '--desktop cpu --opencv cmake --macos_universal'
       iosBuildArgs: '--ios arm64'
       windowsBuildArgs: '--desktop cpu --opencv cmake'
@@ -24,7 +24,7 @@ jobs:
       ref: ${{ github.event.ref }}
       packageName: package-for-production
       linuxBuildArgs: '--linkopt="-s" --desktop gpu --opencv cmake'
-      androidBuildArgs: '--linkopt="-s" --android fat --android_ndk_api_level 21'
+      androidBuildArgs: '--linkopt="-s" --android arm64 --android_ndk_api_level 21'
       macosBuildArgs: '--linkopt="-s" --desktop cpu --opencv cmake --macos_universal'
       iosBuildArgs: '--linkopt="-s" --ios arm64'
       windowsBuildArgs: '--desktop cpu --opencv cmake'


### PR DESCRIPTION
The release packages workflow is failing.
https://github.com/homuler/MediaPipeUnityPlugin/actions/runs/8295012077/job/22701159041

This PR will fix it.