### PR TITLE
Update Modal.cs

### DIFF
--- a/Assets/MediaPipeUnity/Samples/UI/Scripts/Modal.cs
+++ b/Assets/MediaPipeUnity/Samples/UI/Scripts/Modal.cs
@@ -10,7 +10,6 @@ namespace Mediapipe.Unity.Sample.UI
 {
   public class Modal : MonoBehaviour
   {
-    [SerializeField] private Solution _solution; // TODO: remove this field
     [SerializeField] private TaskApiRunner _taskApiRunner;
 
     private GameObject _contents;
@@ -35,7 +34,13 @@ namespace Mediapipe.Unity.Sample.UI
       }
     }
 
-    public void Close()
+    public void OpenAndPause(GameObject contents)
+    {
+      Open(contents);
+      _taskApiRunner?.Pause(); // Use null conditional operator
+    }
+
+    public void CloseAndResume(bool forceRestart = false)
     {
       gameObject.SetActive(false);
 
@@ -43,35 +48,14 @@ namespace Mediapipe.Unity.Sample.UI
       {
         Destroy(_contents);
       }
-    }
 
-    public void CloseAndResume(bool forceRestart = false)
-    {
-      Close();
-
-      if (_solution == null && _taskApiRunner == null)
+      if (_taskApiRunner != null)
       {
-        return;
-      }
-
-      if (forceRestart)
-      {
-        if (_solution != null)
-        {
-          _solution.Play();
-        }
-        if (_taskApiRunner != null)
+        if (forceRestart)
         {
           _taskApiRunner.Play();
         }
-      }
-      else
-      {
-        if (_solution != null)
-        {
-          _solution.Resume();
-        }
-        if (_taskApiRunner != null)
+        else
         {
           _taskApiRunner.Resume();
         }

--- a/Assets/MediaPipeUnity/Samples/UI/Scripts/Modal.cs
+++ b/Assets/MediaPipeUnity/Samples/UI/Scripts/Modal.cs
@@ -24,20 +24,7 @@ namespace Mediapipe.Unity.Sample.UI
     public void OpenAndPause(GameObject contents)
     {
       Open(contents);
-      if (_solution != null)
-      {
-        _solution.Pause();
-      }
-      if (_taskApiRunner != null)
-      {
-        _taskApiRunner.Pause();
-      }
-    }
-
-    public void OpenAndPause(GameObject contents)
-    {
-      Open(contents);
-      _taskApiRunner?.Pause(); // Use null conditional operator
+      _taskApiRunner?.Pause();
     }
 
     public void CloseAndResume(bool forceRestart = false)

--- a/Assets/MediaPipeUnity/Samples/UI/Scripts/ModalContents.cs
+++ b/Assets/MediaPipeUnity/Samples/UI/Scripts/ModalContents.cs
@@ -20,7 +20,7 @@ namespace Mediapipe.Unity.Sample.UI
 
     public virtual void Exit()
     {
-      GetModal().Close();
+      GetModal().CloseAndResume();
     }
 
     protected void InitializeDropdown<T>(Dropdown dropdown, string defaultValue)


### PR DESCRIPTION
Proposed: _solution variable removed, directly check for nullity, and avoid redundancy onto Close & CloseAndResume methods.

* Commented in the code, the _solution field is marked for removal
* Directly check for null before calling Pause or Resume methods in the OpenAndPause and CloseAndResume
*  They share a lot of logic. Combine Close and CloseAndResume into a single method with a boolean flag (forceRestart) to determine the pausing/resuming behavior.