### PR TITLE
fix(sample): stop rotating the input image when running PoseLandmarker

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Scenes/Tasks/Pose Landmark Detection/PoseLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Tasks/Pose Landmark Detection/PoseLandmarkerRunner.cs
@@ -65,7 +65,10 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
       var transformationOptions = imageSource.GetTransformationOptions();
       var flipHorizontally = transformationOptions.flipHorizontally;
       var flipVertically = transformationOptions.flipVertically;
-      var imageProcessingOptions = new Tasks.Vision.Core.ImageProcessingOptions(rotationDegrees: (int)transformationOptions.rotationAngle);
+
+      // Always setting rotationDegrees to 0 to avoid the issue that the detection becomes unstable when the input image is rotated.
+      // https://github.com/homuler/MediaPipeUnityPlugin/issues/1196
+      var imageProcessingOptions = new Tasks.Vision.Core.ImageProcessingOptions(rotationDegrees: 0);
 
       AsyncGPUReadbackRequest req = default;
       var waitUntilReqDone = new WaitUntil(() => req.done);


### PR DESCRIPTION
As a workaround for #1196, stop rotating the input image when running `PoseLandmarker`.
