### PR TITLE
fix: fail to rerun the sample graph

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager.cs
@@ -16,10 +16,10 @@ namespace Mediapipe.Unity
     ///   To make it possible for MediaPipe to read the saved asset, the asset path must be registered
     ///   by calling <see cref="ResourceUtil.AddAssetPath" /> or <see cref="ResourceUtil.SetAssetPath"/> internally.
     /// </remarks>
-    /// <param name="overwrite">
-    ///   Specifies whether <paramref name="uniqueKey" /> will be overwritten if it already exists.
+    /// <param name="overwriteDestination">
+    ///   Specifies whether the destination file will be overwritten if it already exists.
     /// </param>
-    public IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwrite = true);
+    public IEnumerator PrepareAssetAsync(string name, string uniqueKey, bool overwriteDestination = true);
 
     public IEnumerator PrepareAssetAsync(string name, bool overwrite = true) => PrepareAssetAsync(name, name, overwrite);
   }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/AssetBundleResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/AssetBundleResourceManager.cs
@@ -53,19 +53,12 @@ namespace Mediapipe.Unity
       }
     }
 
-    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwrite)
+    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwriteDestination)
     {
       var destFilePath = GetCachePathFor(uniqueKey);
-      if (overwrite)
-      {
-        ResourceUtil.SetAssetPath(name, destFilePath);
-      }
-      else
-      {
-        ResourceUtil.AddAssetPath(name, destFilePath);
-      }
+      ResourceUtil.SetAssetPath(name, destFilePath);
 
-      if (File.Exists(destFilePath) && !overwrite)
+      if (File.Exists(destFilePath) && !overwriteDestination)
       {
         Logger.LogInfo(_TAG, $"{name} will not be copied to {destFilePath} because it already exists");
         yield break;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/LocalResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/LocalResourceManager.cs
@@ -29,19 +29,12 @@ namespace Mediapipe.Unity
 
     public LocalResourceManager() : this("") { }
 
-    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwrite)
+    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwriteDestination)
     {
       var destFilePath = GetCachePathFor(uniqueKey);
-      if (overwrite)
-      {
-        ResourceUtil.SetAssetPath(name, destFilePath);
-      }
-      else
-      {
-        ResourceUtil.AddAssetPath(name, destFilePath);
-      }
+      ResourceUtil.SetAssetPath(name, destFilePath);
 
-      if (File.Exists(destFilePath) && !overwrite)
+      if (File.Exists(destFilePath) && !overwriteDestination)
       {
         Logger.LogInfo(_TAG, $"{name} will not be copied to {destFilePath} because it already exists");
         yield break;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/StreamingAssetsResourceManager.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/ResourceManager/StreamingAssetsResourceManager.cs
@@ -29,19 +29,12 @@ namespace Mediapipe.Unity
 
     public StreamingAssetsResourceManager() : this("") { }
 
-    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwrite)
+    IEnumerator IResourceManager.PrepareAssetAsync(string name, string uniqueKey, bool overwriteDestination)
     {
       var destFilePath = GetCachePathFor(uniqueKey);
-      if (overwrite)
-      {
-        ResourceUtil.SetAssetPath(name, destFilePath);
-      }
-      else
-      {
-        ResourceUtil.AddAssetPath(name, destFilePath);
-      }
+      ResourceUtil.SetAssetPath(name, destFilePath);
 
-      if (File.Exists(destFilePath) && !overwrite)
+      if (File.Exists(destFilePath) && !overwriteDestination)
       {
         Logger.LogInfo(_TAG, $"{name} will not be copied to {destFilePath} because it already exists");
         yield break;
@@ -59,7 +52,7 @@ namespace Mediapipe.Unity
       }
 
       Logger.LogVerbose(_TAG, $"Copying {sourceFilePath} to {destFilePath}...");
-      File.Copy(sourceFilePath, destFilePath, overwrite);
+      File.Copy(sourceFilePath, destFilePath, overwriteDestination);
       Logger.LogVerbose(_TAG, $"{sourceFilePath} is copied to {destFilePath}");
     }
 


### PR DESCRIPTION
Caused by #1210.

Currently, when the sample graph or task runner is rerun (e.g. after changing the config), it fails because the dependent resources is already prepared.

This PR fixes this issue by always overwriting the internal `Dictionary`.
