### PR TITLE
fix: dispose callback arguments immediately

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/FaceLandmarker/FaceLandmarker.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/FaceLandmarker/FaceLandmarker.cs
@@ -251,13 +251,13 @@ namespace Mediapipe.Tasks.Vision.FaceLandmarker
 
       return (PacketMap outputPackets) =>
       {
-        var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
+        using var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
         if (outImagePacket == null || outImagePacket.IsEmpty())
         {
           return;
         }
 
-        var image = outImagePacket.Get();
+        using var image = outImagePacket.Get();
         var timestamp = outImagePacket.TimestampMicroseconds() / _MICRO_SECONDS_PER_MILLISECOND;
 
         if (TryBuildFaceLandmarkerResult(outputPackets, faceGeometriesForRead, ref faceLandmarkerResult))

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/HandLandmarker/HandLandmarker.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/HandLandmarker/HandLandmarker.cs
@@ -232,13 +232,13 @@ namespace Mediapipe.Tasks.Vision.HandLandmarker
 
       return (PacketMap outputPackets) =>
       {
-        var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
+        using var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
         if (outImagePacket == null || outImagePacket.IsEmpty())
         {
           return;
         }
 
-        var image = outImagePacket.Get();
+        using var image = outImagePacket.Get();
         var timestamp = outImagePacket.TimestampMicroseconds() / _MICRO_SECONDS_PER_MILLISECOND;
 
         if (TryBuildHandLandmarkerResult(outputPackets, ref handLandmarkerResult))

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/ImageSegmenter/ImageSegmenter.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/ImageSegmenter/ImageSegmenter.cs
@@ -250,13 +250,13 @@ namespace Mediapipe.Tasks.Vision.ImageSegmenter
 
       return (PacketMap outputPackets) =>
       {
-        var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
+        using var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
         if (outImagePacket == null || outImagePacket.IsEmpty())
         {
           return;
         }
 
-        var image = outImagePacket.Get();
+        using var image = outImagePacket.Get();
         var timestamp = outImagePacket.TimestampMicroseconds() / _MICRO_SECONDS_PER_MILLISECOND;
 
         if (TryBuildImageSegmenterResult(outputPackets, ref segmentationResult))

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/PoseLandmarker/PoseLandmarker.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/PoseLandmarker/PoseLandmarker.cs
@@ -232,13 +232,13 @@ namespace Mediapipe.Tasks.Vision.PoseLandmarker
 
       return (PacketMap outputPackets) =>
       {
-        var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
+        using var outImagePacket = outputPackets.At<Image>(_IMAGE_OUT_STREAM_NAME);
         if (outImagePacket == null || outImagePacket.IsEmpty())
         {
           return;
         }
 
-        var image = outImagePacket.Get();
+        using var image = outImagePacket.Get();
         var timestamp = outImagePacket.TimestampMicroseconds() / _MICRO_SECONDS_PER_MILLISECOND;
 
         if (TryBuildPoseLandmarkerResult(outputPackets, ref poseLandmarkerResult))


### PR DESCRIPTION
For now, the input `Image` isn't released immediately even if it cannot be reached anymore.