### PR TITLE
build: change the default AssetLoader type

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -283,25 +283,7 @@ jobs:
         run: |
           rm MediaPipeUnityPlugin-all.zip
 
-      - name: Export tarball
-        run: |
-          cd Packages/com.github.homuler.mediapipe
-          npm pack
-          mv com.github.homuler.mediapipe-*.tgz ../..
-
-      - name: Upload the tarball package
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.packageName }}-tarball
-          path: |
-            com.github.homuler.mediapipe-*.tgz
-          retention-days: 7
-
-      # avoid "No space left on device" error
-      - name: Remove uploaded files to free up space
-        run: |
-          rm com.github.homuler.mediapipe-*.tgz
-
+      # NOTE: this step will overwrite AppSettings.asset
       - name: Export unitypackage
         if: ${{ env.BUILD_UNITYPACKAGE == '1' }}
         run: |
@@ -314,6 +296,20 @@ jobs:
           name: ${{ inputs.packageName }}-unitypackage
           path: |
             *.unitypackage
+          retention-days: 7
+
+      - name: Export tarball
+        run: |
+          cd Packages/com.github.homuler.mediapipe
+          npm pack
+          mv com.github.homuler.mediapipe-*.tgz ../..
+
+      - name: Upload the tarball package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.packageName }}-tarball
+          path: |
+            com.github.homuler.mediapipe-*.tgz
           retention-days: 7
 
   clean:

--- a/Assets/MediaPipeUnity/Editor/PackageExporter.cs
+++ b/Assets/MediaPipeUnity/Editor/PackageExporter.cs
@@ -34,6 +34,9 @@ public static class PackageExporter
   [MenuItem("Tools/Export Unitypackage")]
   public static void Export()
   {
+    // Default Asset Loader Type is Local
+    OverwriteAssetLoaderType(Mediapipe.Unity.Sample.AppSettings.AssetLoaderType.Local);
+
     var packageRoot = Path.Combine(Application.dataPath, "..", "Packages", "com.github.homuler.mediapipe");
     var version = GetVersion(packageRoot);
 
@@ -99,6 +102,16 @@ public static class PackageExporter
     }
 
     return version;
+  }
+
+  private static void OverwriteAssetLoaderType(Mediapipe.Unity.Sample.AppSettings.AssetLoaderType assetLoaderType)
+  {
+    var appSettings = AssetDatabase.LoadAssetAtPath<Mediapipe.Unity.Sample.AppSettings>("Assets/MediaPipeUnity/Samples/Scenes/AppSettings.asset");
+    appSettings.assetLoaderType = assetLoaderType;
+
+    EditorUtility.SetDirty(appSettings);
+    AssetDatabase.SaveAssets();
+    AssetDatabase.Refresh();
   }
 
   public class PackageJson

--- a/Assets/MediaPipeUnity/Samples/Common/Scripts/AppSettings.cs
+++ b/Assets/MediaPipeUnity/Samples/Common/Scripts/AppSettings.cs
@@ -61,7 +61,11 @@ namespace Mediapipe.Unity.Sample
 
     public ImageSourceType defaultImageSource => _defaultImageSource;
     public InferenceMode preferableInferenceMode => _preferableInferenceMode;
-    public AssetLoaderType assetLoaderType => _assetLoaderType;
+    public AssetLoaderType assetLoaderType
+    {
+      get => _assetLoaderType;
+      set => _assetLoaderType = value;
+    }
     public Logger.LogLevel logLevel => _logLevel;
 
     public void ResetGlogFlags()

--- a/Assets/MediaPipeUnity/Samples/Scenes/AppSettings.asset
+++ b/Assets/MediaPipeUnity/Samples/Scenes/AppSettings.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _defaultImageSource: 0
   _preferableInferenceMode: 0
-  _assetLoaderType: 2
+  _assetLoaderType: 0
   _logLevel: 5
   _glogMinloglevel: 0
   _glogStderrthreshold: 2


### PR DESCRIPTION
Since we often receive inquiries about built apps not running, I will change the default value of `AssetLoaderType`, excluding exported packages.