### PR TITLE
fix: avoid HERMETIC_PYTHON_VERSION errors

### DIFF
--- a/docker/linux/x86_64/Dockerfile
+++ b/docker/linux/x86_64/Dockerfile
@@ -61,7 +61,8 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get install -y --no-install-recommends python3.12 python3.12-dev python3.12-venv python3-pip && \
     curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python3.12 get-pip.py && \
-    update-alternatives --install /usr/local/bin/python python /usr/bin/python3.12 10
+    update-alternatives --install /usr/bin/python python /usr/bin/python3.12 10 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 10
 
 
 FROM base AS android


### PR DESCRIPTION
Avoid hermetic python version errors.

cf. https://github.com/homuler/MediaPipeUnityPlugin/actions/runs/12610418764
```txt
Could not find requirements_lock.txt file matching specified Python version.
Specified python version: 3.8
```