### PR TITLE
fix: deep clone result to avoid data race

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ClassificationResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ClassificationResult.cs
@@ -90,6 +90,21 @@ namespace Mediapipe.Tasks.Components.Containers
       destination = new Classifications(categories, source.headIndex, source.headName);
     }
 
+    public void CloneTo(ref Classifications destination)
+    {
+      if (categories == null)
+      {
+        destination = default;
+        return;
+      }
+
+      var dstCategories = destination.categories ?? new List<Category>(categories.Count);
+      dstCategories.Clear();
+      dstCategories.AddRange(categories);
+
+      destination = new Classifications(categories, headIndex, headName);
+    }
+
     public override string ToString()
       => $"{{ \"categories\": {Util.Format(categories)}, \"headIndex\": {headIndex}, \"headName\": {Util.Format(headName)} }}";
   }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/Landmark.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/Landmark.cs
@@ -218,6 +218,21 @@ namespace Mediapipe.Tasks.Components.Containers
       destination = new Landmarks(landmarks);
     }
 
+    public void CloneTo(ref Landmarks destination)
+    {
+      if (landmarks == null)
+      {
+        destination = default;
+        return;
+      }
+
+      var dstLandmarks = destination.landmarks ?? new List<Landmark>(landmarks.Count);
+      dstLandmarks.Clear();
+      dstLandmarks.AddRange(landmarks);
+
+      destination = new Landmarks(dstLandmarks);
+    }
+
     public override string ToString() => $"{{ \"landmarks\": {Util.Format(landmarks)} }}";
   }
 
@@ -267,48 +282,21 @@ namespace Mediapipe.Tasks.Components.Containers
       destination = new NormalizedLandmarks(landmarks);
     }
 
+    public void CloneTo(ref NormalizedLandmarks destination)
+    {
+      if (landmarks == null)
+      {
+        destination = default;
+        return;
+      }
+
+      var dstLandmarks = destination.landmarks ?? new List<NormalizedLandmark>(landmarks.Count);
+      dstLandmarks.Clear();
+      dstLandmarks.AddRange(landmarks);
+
+      destination = new NormalizedLandmarks(dstLandmarks);
+    }
+
     public override string ToString() => $"{{ \"landmarks\": {Util.Format(landmarks)} }}";
-  }
-
-  internal static class NativeLandmarksArrayExtension
-  {
-    public static void FillWith(this List<ClassificationResult> target, NativeClassificationResultArray source)
-    {
-      target.ResizeTo(source.size);
-
-      var i = 0;
-      foreach (var nativeClassificationResult in source.AsReadOnlySpan())
-      {
-        var classificationResult = target[i];
-        ClassificationResult.Copy(nativeClassificationResult, ref classificationResult);
-        target[i++] = classificationResult;
-      }
-    }
-
-    public static void FillWith(this List<Landmarks> target, NativeLandmarksArray source)
-    {
-      target.ResizeTo(source.size);
-
-      var i = 0;
-      foreach (var nativeLandmarks in source.AsReadOnlySpan())
-      {
-        var landmarks = target[i];
-        Landmarks.Copy(nativeLandmarks, ref landmarks);
-        target[i++] = landmarks;
-      }
-    }
-
-    public static void FillWith(this List<NormalizedLandmarks> target, NativeNormalizedLandmarksArray source)
-    {
-      target.ResizeTo(source.size);
-
-      var i = 0;
-      foreach (var nativeLandmarks in source.AsReadOnlySpan())
-      {
-        var landmarks = target[i];
-        NormalizedLandmarks.Copy(nativeLandmarks, ref landmarks);
-        target[i++] = landmarks;
-      }
-    }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 homuler
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+using System.Collections.Generic;
+
+namespace Mediapipe.Tasks.Components.Containers
+{
+  internal static class ListExtension
+  {
+    public static void CopyFrom(this List<Classifications> target, List<Classifications> source)
+    {
+      target.ResizeTo(source.Count);
+
+      var i = 0;
+      foreach (var x in source)
+      {
+        var v = target[i];
+        x.CloneTo(ref v);
+        target[i++] = v;
+      }
+    }
+
+    public static void CopyFrom(this List<Landmarks> target, List<Landmarks> source)
+    {
+      target.ResizeTo(source.Count);
+
+      var i = 0;
+      foreach (var x in source)
+      {
+        var v = target[i];
+        x.CloneTo(ref v);
+        target[i++] = v;
+      }
+    }
+
+    public static void CopyFrom(this List<NormalizedLandmarks> target, List<NormalizedLandmarks> source)
+    {
+      target.ResizeTo(source.Count);
+
+      var i = 0;
+      foreach (var x in source)
+      {
+        var v = target[i];
+        x.CloneTo(ref v);
+        target[i++] = v;
+      }
+    }
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06176432e1f6f57458a9411080a3debd

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/NativeArrayExtension.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/NativeArrayExtension.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 homuler
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+using System.Collections.Generic;
+
+namespace Mediapipe.Tasks.Components.Containers
+{
+  internal static class NativeContainerArrayExtension
+  {
+    public static void FillWith(this List<ClassificationResult> target, NativeClassificationResultArray source)
+    {
+      target.ResizeTo(source.size);
+
+      var i = 0;
+      foreach (var nativeClassificationResult in source.AsReadOnlySpan())
+      {
+        var classificationResult = target[i];
+        ClassificationResult.Copy(nativeClassificationResult, ref classificationResult);
+        target[i++] = classificationResult;
+      }
+    }
+
+    public static void FillWith(this List<Landmarks> target, NativeLandmarksArray source)
+    {
+      target.ResizeTo(source.size);
+
+      var i = 0;
+      foreach (var nativeLandmarks in source.AsReadOnlySpan())
+      {
+        var landmarks = target[i];
+        Landmarks.Copy(nativeLandmarks, ref landmarks);
+        target[i++] = landmarks;
+      }
+    }
+
+    public static void FillWith(this List<NormalizedLandmarks> target, NativeNormalizedLandmarksArray source)
+    {
+      target.ResizeTo(source.size);
+
+      var i = 0;
+      foreach (var nativeLandmarks in source.AsReadOnlySpan())
+      {
+        var landmarks = target[i];
+        NormalizedLandmarks.Copy(nativeLandmarks, ref landmarks);
+        target[i++] = landmarks;
+      }
+    }
+  }
+}

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/NativeArrayExtension.cs.meta
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/NativeArrayExtension.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c34635d4af97002f585f664264895de1

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/FaceLandmarker/FaceLandmarkerResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/FaceLandmarker/FaceLandmarkerResult.cs
@@ -53,15 +53,13 @@ namespace Mediapipe.Tasks.Vision.FaceLandmarker
       }
 
       var dstFaceLandmarks = destination.faceLandmarks ?? new List<NormalizedLandmarks>(faceLandmarks.Count);
-      dstFaceLandmarks.Clear();
-      dstFaceLandmarks.AddRange(faceLandmarks);
+      dstFaceLandmarks.CopyFrom(faceLandmarks);
 
       var dstFaceBlendshapes = destination.faceBlendshapes;
       if (faceBlendshapes != null)
       {
         dstFaceBlendshapes ??= new List<Classifications>(faceBlendshapes.Count);
-        dstFaceBlendshapes.Clear();
-        dstFaceBlendshapes.AddRange(faceBlendshapes);
+        dstFaceBlendshapes.CopyFrom(faceBlendshapes);
       }
 
       var dstFacialTransformationMatrixes = destination.facialTransformationMatrixes;

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/HandLandmarker/HandLandmarkerResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/HandLandmarker/HandLandmarkerResult.cs
@@ -52,16 +52,13 @@ namespace Mediapipe.Tasks.Vision.HandLandmarker
       }
 
       var dstHandedness = destination.handedness ?? new List<Classifications>(handedness.Count);
-      dstHandedness.Clear();
-      dstHandedness.AddRange(handedness);
+      dstHandedness.CopyFrom(handedness);
 
       var dstHandLandmarks = destination.handLandmarks ?? new List<NormalizedLandmarks>(handLandmarks.Count);
-      dstHandLandmarks.Clear();
-      dstHandLandmarks.AddRange(handLandmarks);
+      dstHandLandmarks.CopyFrom(handLandmarks);
 
       var dstHandWorldLandmarks = destination.handWorldLandmarks ?? new List<Landmarks>(handWorldLandmarks.Count);
-      dstHandWorldLandmarks.Clear();
-      dstHandWorldLandmarks.AddRange(handWorldLandmarks);
+      dstHandWorldLandmarks.CopyFrom(handWorldLandmarks);
 
       destination = new HandLandmarkerResult(dstHandedness, dstHandLandmarks, dstHandWorldLandmarks);
     }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/PoseLandmarker/PoseLandmarkerResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/PoseLandmarker/PoseLandmarkerResult.cs
@@ -56,12 +56,10 @@ namespace Mediapipe.Tasks.Vision.PoseLandmarker
       }
 
       var dstPoseLandmarks = destination.poseLandmarks ?? new List<NormalizedLandmarks>(poseLandmarks.Count);
-      dstPoseLandmarks.Clear();
-      dstPoseLandmarks.AddRange(poseLandmarks);
+      dstPoseLandmarks.CopyFrom(poseLandmarks);
 
       var dstPoseWorldLandmarks = destination.poseWorldLandmarks ?? new List<Landmarks>(poseWorldLandmarks.Count);
-      dstPoseWorldLandmarks.Clear();
-      dstPoseWorldLandmarks.AddRange(poseWorldLandmarks);
+      dstPoseWorldLandmarks.CopyFrom(poseWorldLandmarks);
 
       var dstSegmentationMasks = destination.segmentationMasks;
       if (segmentationMasks != null)


### PR DESCRIPTION
related to #1223 

Currently, when the task runner is in LIVE_STREAM mode, some data (e.g. Landmark.landmarks) is not deep copied correctly.