### PR TITLE
fix: read masks immediately to avoid crash and memory leaks

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Scenes/Image Segmentation/ImageSegmenterRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Image Segmentation/ImageSegmenterRunner.cs
@@ -123,6 +123,7 @@ namespace Mediapipe.Unity.Sample.ImageSegmentation
             {
               _imageSegmenterResultAnnotationController.DrawNow(default);
             }
+            DisposeAllMasks(result);
             break;
           case Tasks.Vision.Core.RunningMode.VIDEO:
             if (taskApi.TrySegmentForVideo(image, GetCurrentTimestampMillisec(), imageProcessingOptions, ref result))
@@ -133,6 +134,7 @@ namespace Mediapipe.Unity.Sample.ImageSegmentation
             {
               _imageSegmenterResultAnnotationController.DrawNow(default);
             }
+            DisposeAllMasks(result);
             break;
           case Tasks.Vision.Core.RunningMode.LIVE_STREAM:
             taskApi.SegmentAsync(image, GetCurrentTimestampMillisec(), imageProcessingOptions);
@@ -141,6 +143,19 @@ namespace Mediapipe.Unity.Sample.ImageSegmentation
       }
     }
 
-    private void OnImageSegmentationOutput(ImageSegmenterResult result, Image image, long timestamp) => _imageSegmenterResultAnnotationController.DrawLater(result);
+    private void OnImageSegmentationOutput(ImageSegmenterResult result, Image image, long timestamp)
+    {
+      _imageSegmenterResultAnnotationController.DrawLater(result);
+      DisposeAllMasks(result);
+    }
+
+    private void DisposeAllMasks(ImageSegmenterResult result)
+    {
+      foreach (var mask in result.confidenceMasks)
+      {
+        mask.Dispose();
+      }
+      result.categoryMask?.Dispose();
+    }
   }
 }

--- a/Assets/MediaPipeUnity/Samples/Scenes/Pose Landmark Detection/PoseLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Pose Landmark Detection/PoseLandmarkerRunner.cs
@@ -126,6 +126,7 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
             {
               _poseLandmarkerResultAnnotationController.DrawNow(default);
             }
+            DisposeAllMasks(result);
             break;
           case Tasks.Vision.Core.RunningMode.VIDEO:
             if (taskApi.TryDetectForVideo(image, GetCurrentTimestampMillisec(), imageProcessingOptions, ref result))
@@ -136,6 +137,7 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
             {
               _poseLandmarkerResultAnnotationController.DrawNow(default);
             }
+            DisposeAllMasks(result);
             break;
           case Tasks.Vision.Core.RunningMode.LIVE_STREAM:
             taskApi.DetectAsync(image, GetCurrentTimestampMillisec(), imageProcessingOptions);
@@ -144,6 +146,21 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
       }
     }
 
-    private void OnPoseLandmarkDetectionOutput(PoseLandmarkerResult result, Image image, long timestamp) => _poseLandmarkerResultAnnotationController.DrawLater(result);
+    private void OnPoseLandmarkDetectionOutput(PoseLandmarkerResult result, Image image, long timestamp)
+    {
+      _poseLandmarkerResultAnnotationController.DrawLater(result);
+      DisposeAllMasks(result);
+    }
+
+    private void DisposeAllMasks(PoseLandmarkerResult result)
+    {
+      if (result.segmentationMasks != null)
+      {
+        foreach (var mask in result.segmentationMasks)
+        {
+          mask.Dispose();
+        }
+      }
+    }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/ImageSegmenter/ImageSegmenterResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Vision/ImageSegmenter/ImageSegmenterResult.cs
@@ -35,19 +35,5 @@ namespace Mediapipe.Tasks.Vision.ImageSegmenter
       var confidenceMasks = outputConfidenceMasks ? new List<Image>() : null;
       return new ImageSegmenterResult(confidenceMasks, null);
     }
-
-    public void CloneTo(ref ImageSegmenterResult destination)
-    {
-      var dstConfidenceMasks = destination.confidenceMasks;
-      dstConfidenceMasks?.Clear();
-      if (confidenceMasks != null)
-      {
-        dstConfidenceMasks ??= new List<Image>(confidenceMasks.Count);
-        dstConfidenceMasks.Clear();
-        dstConfidenceMasks.AddRange(confidenceMasks);
-      }
-
-      destination = new ImageSegmenterResult(dstConfidenceMasks, categoryMask);
-    }
   }
 }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/ImageSegmenterResultAnnotationController.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/ImageSegmenterResultAnnotationController.cs
@@ -34,6 +34,7 @@ namespace Mediapipe.Unity
     public void DrawNow(ImageSegmenterResult target)
     {
       _currentTarget = target;
+      ReadCurrentMasks();
       SyncNow();
     }
 
@@ -43,7 +44,8 @@ namespace Mediapipe.Unity
     {
       lock (_currentTargetLock)
       {
-        newTarget.CloneTo(ref _currentTarget);
+        _currentTarget = newTarget;
+        ReadCurrentMasks();
         isStale = true;
       }
     }
@@ -53,16 +55,19 @@ namespace Mediapipe.Unity
       lock (_currentTargetLock)
       {
         isStale = false;
-        if (_currentTarget.confidenceMasks?.Count > _maskIndex)
-        {
-          annotation.Draw(_currentTarget.confidenceMasks[_maskIndex], isMirrored);
-        }
-        // TODO: stop disposing masks here
-        foreach (var mask in _currentTarget.confidenceMasks)
-        {
-          mask.Dispose();
-        }
-        _currentTarget.categoryMask?.Dispose();
+        annotation.Draw();
+      }
+    }
+
+    private void ReadCurrentMasks()
+    {
+      if (_currentTarget.confidenceMasks?.Count > _maskIndex)
+      {
+        annotation.Read(_currentTarget.confidenceMasks[_maskIndex], isMirrored);
+      }
+      else
+      {
+        annotation.Clear();
       }
     }
   }

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PoseLandmarkerResultAnnotationController.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/PoseLandmarkerResultAnnotationController.cs
@@ -22,6 +22,12 @@ namespace Mediapipe.Unity
     public void DrawNow(PoseLandmarkerResult target)
     {
       target.CloneTo(ref _currentTarget);
+      if (_currentTarget.segmentationMasks != null)
+      {
+        ReadMask(_currentTarget.segmentationMasks);
+        // NOTE: segmentationMasks can still be accessed from newTarget.
+        _currentTarget.segmentationMasks.Clear();
+      }
       SyncNow();
     }
 
@@ -34,6 +40,12 @@ namespace Mediapipe.Unity
       lock (_currentTargetLock)
       {
         newTarget.CloneTo(ref _currentTarget);
+        if (_currentTarget.segmentationMasks != null)
+        {
+          ReadMask(_currentTarget.segmentationMasks);
+          // NOTE: segmentationMasks can still be accessed from newTarget.
+          _currentTarget.segmentationMasks.Clear();
+        }
         isStale = true;
       }
     }
@@ -43,15 +55,6 @@ namespace Mediapipe.Unity
       lock (_currentTargetLock)
       {
         isStale = false;
-        if (_currentTarget.segmentationMasks != null)
-        {
-          ReadMask(_currentTarget.segmentationMasks);
-          // TODO: stop disposing masks here
-          foreach (var mask in _currentTarget.segmentationMasks)
-          {
-            mask.Dispose();
-          }
-        }
         annotation.Draw(_currentTarget.poseLandmarks, _visualizeZ);
       }
     }


### PR DESCRIPTION
Currently, when drawing a segmentation mask for annotation, data is not read immediately, so the AnnotationController manages the lifecycle of the mask. Depending on how the code is written, this can easily lead to crashes.

In this PR, we changed the process to read the segmentation mask immediately, allowing the mask to be disposed of without relying on the AnnotationController.