### PR TITLE
fix: copy categories correctly

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ClassificationResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ClassificationResult.cs
@@ -102,7 +102,7 @@ namespace Mediapipe.Tasks.Components.Containers
       dstCategories.Clear();
       dstCategories.AddRange(categories);
 
-      destination = new Classifications(categories, headIndex, headName);
+      destination = new Classifications(dstCategories, headIndex, headName);
     }
 
     public override string ToString()


### PR DESCRIPTION
caused by #1302 

Fixed an issue where categories were mistakenly cleared when copying them.