### PR TITLE
fix: acquire a lock when drawing DetectionResult annotations

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/DetectionResult.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/DetectionResult.cs
@@ -113,6 +113,29 @@ namespace Mediapipe.Tasks.Components.Containers
       destination = new Detection(categories, boundingBox, keypoints);
     }
 
+    public void CloneTo(ref Detection destination)
+    {
+      if (categories == null)
+      {
+        destination = default;
+        return;
+      }
+
+      var dstCategories = destination.categories ?? new List<Category>(categories.Count);
+      dstCategories.Clear();
+      dstCategories.AddRange(categories);
+
+      var dstKeypoints = destination.keypoints;
+      if (keypoints != null)
+      {
+        dstKeypoints ??= new List<NormalizedKeypoint>(keypoints.Count);
+        dstKeypoints.Clear();
+        dstKeypoints.AddRange(keypoints);
+      }
+
+      destination = new Detection(dstCategories, boundingBox, dstKeypoints);
+    }
+
     public override string ToString()
       => $"{{ \"categories\": {Util.Format(categories)}, \"boundingBox\": {boundingBox}, \"keypoints\": {Util.Format(keypoints)} }}";
   }
@@ -171,6 +194,20 @@ namespace Mediapipe.Tasks.Components.Containers
       }
 
       destination = new DetectionResult(detections);
+    }
+
+    public void CloneTo(ref DetectionResult destination)
+    {
+      if (detections == null)
+      {
+        destination = default;
+        return;
+      }
+
+      var dstDetections = destination.detections ?? new List<Detection>(detections.Count);
+      dstDetections.CopyFrom(detections);
+
+      destination = new DetectionResult(dstDetections);
     }
 
     public override string ToString() => $"{{ \"detections\": {Util.Format(detections)} }}";

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Tasks/Components/Containers/ListExtension.cs
@@ -23,6 +23,19 @@ namespace Mediapipe.Tasks.Components.Containers
       }
     }
 
+    public static void CopyFrom(this List<Detection> target, List<Detection> source)
+    {
+      target.ResizeTo(source.Count);
+
+      var i = 0;
+      foreach (var x in source)
+      {
+        var v = target[i];
+        x.CloneTo(ref v);
+        target[i++] = v;
+      }
+    }
+
     public static void CopyFrom(this List<Landmarks> target, List<Landmarks> source)
     {
       target.ResizeTo(source.Count);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionResultAnnotationController.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Annotation/DetectionResultAnnotationController.cs
@@ -14,6 +14,7 @@ namespace Mediapipe.Unity
   {
     [SerializeField, Range(0, 1)] private float _threshold = 0.0f;
 
+    private readonly object _currentTargetLock = new object();
     private mptcc.DetectionResult _currentTarget;
 
     public void DrawNow(mptcc.DetectionResult target)
@@ -22,12 +23,24 @@ namespace Mediapipe.Unity
       SyncNow();
     }
 
-    public void DrawLater(mptcc.DetectionResult target) => UpdateCurrentTarget(target, ref _currentTarget);
+    public void DrawLater(mptcc.DetectionResult target) => UpdateCurrentTarget(target);
+
+    protected void UpdateCurrentTarget(mptcc.DetectionResult newTarget)
+    {
+      lock (_currentTargetLock)
+      {
+        newTarget.CloneTo(ref _currentTarget);
+        isStale = true;
+      }
+    }
 
     protected override void SyncNow()
     {
-      isStale = false;
-      annotation.Draw(_currentTarget, imageSize, _threshold);
+      lock (_currentTargetLock)
+      {
+        isStale = false;
+        annotation.Draw(_currentTarget, imageSize, _threshold);
+      }
     }
   }
 }


### PR DESCRIPTION
Fix an issue with DetectionResult, similar to #1305.