### PR TITLE
Resolve landmark jitter by adjusting frame copy timing

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Scenes/Face Detection/FaceDetectorRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Face Detection/FaceDetectorRunner.cs
@@ -87,8 +87,6 @@ namespace Mediapipe.Unity.Sample.FaceDetection
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -100,8 +98,12 @@ namespace Mediapipe.Unity.Sample.FaceDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Face Landmark Detection/FaceLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Face Landmark Detection/FaceLandmarkerRunner.cs
@@ -88,8 +88,6 @@ namespace Mediapipe.Unity.Sample.FaceLandmarkDetection
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -101,11 +99,13 @@ namespace Mediapipe.Unity.Sample.FaceLandmarkDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPUAsync:
           default:
@@ -115,6 +115,7 @@ namespace Mediapipe.Unity.Sample.FaceLandmarkDetection
             if (req.hasError)
             {
               Debug.LogWarning($"Failed to read texture from the image source");
+              yield return waitForEndOfFrame;
               continue;
             }
             image = textureFrame.BuildCPUImage();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Face Landmark Detection/FaceLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Face Landmark Detection/FaceLandmarkerRunner.cs
@@ -99,13 +99,15 @@ namespace Mediapipe.Unity.Sample.FaceLandmarkDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
             yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();
-            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPUAsync:
           default:
@@ -115,7 +117,6 @@ namespace Mediapipe.Unity.Sample.FaceLandmarkDetection
             if (req.hasError)
             {
               Debug.LogWarning($"Failed to read texture from the image source");
-              yield return waitForEndOfFrame;
               continue;
             }
             image = textureFrame.BuildCPUImage();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Hand Landmark Detection/HandLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Hand Landmark Detection/HandLandmarkerRunner.cs
@@ -86,8 +86,6 @@ namespace Mediapipe.Unity.Sample.HandLandmarkDetection
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -99,8 +97,12 @@ namespace Mediapipe.Unity.Sample.HandLandmarkDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Image Segmentation/ImageSegmenterRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Image Segmentation/ImageSegmenterRunner.cs
@@ -89,8 +89,6 @@ namespace Mediapipe.Unity.Sample.ImageSegmentation
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -102,8 +100,12 @@ namespace Mediapipe.Unity.Sample.ImageSegmentation
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Object Detection/ObjectDetectorRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Object Detection/ObjectDetectorRunner.cs
@@ -86,8 +86,6 @@ namespace Mediapipe.Unity.Sample.ObjectDetection
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -99,8 +97,12 @@ namespace Mediapipe.Unity.Sample.ObjectDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();

--- a/Assets/MediaPipeUnity/Samples/Scenes/Pose Landmark Detection/PoseLandmarkerRunner.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Pose Landmark Detection/PoseLandmarkerRunner.cs
@@ -92,8 +92,6 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
           continue;
         }
 
-        yield return waitForEndOfFrame;
-
         // Build the input Image
         Image image;
         switch (config.ImageReadMode)
@@ -105,8 +103,12 @@ namespace Mediapipe.Unity.Sample.PoseLandmarkDetection
             }
             textureFrame.ReadTextureOnGPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildGPUImage(glContext);
+            // TODO: Currently we wait here for one frame to make sure the texture is fully copied to the TextureFrame before sending it to MediaPipe.
+            // This usually works but is not guaranteed. Find a proper way to do this. See: https://github.com/homuler/MediaPipeUnityPlugin/pull/1311
+            yield return waitForEndOfFrame;
             break;
           case ImageReadMode.CPU:
+            yield return waitForEndOfFrame;
             textureFrame.ReadTextureOnCPU(imageSource.GetCurrentTexture(), flipHorizontally, flipVertically);
             image = textureFrame.BuildCPUImage();
             textureFrame.Release();


### PR DESCRIPTION
Potential fix for https://github.com/homuler/MediaPipeUnityPlugin/issues/1238 

I've only implemented this for the `FaceLandmarkerRunner` for now because I wanted to get your thoughts on it first.

---

I've noticed that on my Samsung S21 when using `ImageReadMode.GPU`, the video would "glitch" in a weird way. The detected landmarks would look like they jumped back in time a few frames randomly from time to time, which is also what's visible in the slo-mo video from https://github.com/homuler/MediaPipeUnityPlugin/issues/1238 . It gets especially bad when I turn on `Multithreaded Rendering` in the Android build settings.

After some digging, I believe this is because the GPU operations that copy the frame data to the `TextureFrame` texture aren't guaranteed to finish before sending it off to MediaPipe via `taskApi.DetectAsync(...)`. This causes the `TextureFrame` from the pool to potentially still have its previous texture content, which would be an old frame.

One easy fix for that would be to move the `yield return waitForEndOfFrame;` _after_ the GPU copy operations. That way, the copy operations are finished before the frame is sent off. This fixes the issue entirely on my device.

However, I'm not actually sure this is a proper fix as I don't think Unity technically _guarantees_ that graphics operations will be finished within one frame. I was trying to use a `GraphicsFence`, but apparently that's not supported on Android.

Let me know what you think.

<--- before / after --->

https://github.com/user-attachments/assets/55c12331-891b-463e-92b8-00e89fddcf92





