### PR TITLE
fix: Destroy textures to fix memory leak

### DIFF
--- a/Assets/MediaPipeUnity/Samples/Scenes/Legacy/Holistic/HolisticTrackingSolution.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Legacy/Holistic/HolisticTrackingSolution.cs
@@ -63,6 +63,13 @@ namespace Mediapipe.Unity.Sample.Holistic
       set => graphRunner.minTrackingConfidence = value;
     }
 
+    public override void Stop()
+    {
+      base.Stop();
+      _textureFramePool?.Dispose();
+      _textureFramePool = null;
+    }
+
     protected override IEnumerator Run()
     {
       var graphInitRequest = graphRunner.WaitForInit(runningMode);

--- a/Assets/MediaPipeUnity/Samples/Scenes/Legacy/MediaPipe Video/MediaPipeVideoSolution.cs
+++ b/Assets/MediaPipeUnity/Samples/Scenes/Legacy/MediaPipe Video/MediaPipeVideoSolution.cs
@@ -15,6 +15,14 @@ namespace Mediapipe.Unity.Sample.MediaPipeVideo
     private Texture2D _outputTexture;
     private Experimental.TextureFramePool _textureFramePool;
 
+    public override void Stop()
+    {
+      base.Stop();
+      _textureFramePool?.Dispose();
+      _textureFramePool = null;
+      Destroy(_outputTexture);
+    }
+
     protected override IEnumerator Run()
     {
       var graphInitRequest = graphRunner.WaitForInit(runningMode);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs
@@ -93,6 +93,7 @@ namespace Mediapipe.Unity.Experimental
       }
       _glSyncToken?.Dispose();
       _ = _InstanceTable.Remove(_instanceId);
+      MonoBehaviour.Destroy(_texture);
     }
 
     public void CopyTexture(Texture dst) => Graphics.CopyTexture(_texture, dst);

--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs
@@ -93,7 +93,7 @@ namespace Mediapipe.Unity.Experimental
       }
       _glSyncToken?.Dispose();
       _ = _InstanceTable.Remove(_instanceId);
-      MonoBehaviour.Destroy(_texture);
+      UnityEngine.Object.Destroy(_texture);
     }
 
     public void CopyTexture(Texture dst) => Graphics.CopyTexture(_texture, dst);


### PR DESCRIPTION
Thank you for this nice plugin!

I found a memory leak problem and it cause runtime crash on iPhone.
It happens when I repeat Instantiate and Destroy components (ex. Holistic solution) via my script.
In memory profiler, Texture2D was increasing and leaking,
![image](https://github.com/user-attachments/assets/e35be882-ddad-4635-bbed-7107cd8b0888)
 and those textures seem to have been generated by TextureFrames.
![image](https://github.com/user-attachments/assets/d0182f92-e398-444d-a046-d9ae513d9dfd)

After adding Destroy() in `Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs`, it's fixed.

I confirmed about `Packages/com.github.homuler.mediapipe/Runtime/Scripts/Unity/Experimental/TextureFrame.cs`, but I don't know how should I do about `Assets/MediaPipeUnity/Samples/Common/Scripts/ImageSource/TextureFrame.cs`.

This Pull Request is just for your information.