### PR TITLE
ci: windows-2019 has been retired

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -164,7 +164,7 @@ jobs:
           path: Packages/com.github.homuler.mediapipe/Runtime/Plugins/iOS
 
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -35,7 +35,7 @@ jobs:
             Packages/com.github.homuler.mediapipe/Runtime/Scripts/Protobuf/**/*.cs
             Packages/com.github.homuler.mediapipe/PackageResources/MediaPipe/*.bytes
             Packages/com.github.homuler.mediapipe/PackageResources/MediaPipe/*.txt
-          key: libs-windows-2019-v1-${{ hashFiles('cache_key.txt') }}
+          key: libs-windows-2022-v1-${{ hashFiles('cache_key.txt') }}
 
       - name: Remove cache_key.txt
         run: |
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
         unity:
           - { version: "6000.0.33f1", changeset: "433b0a79340b" }
           - { version: "2022.3.55f1", changeset: "9f374180d209" }


### PR DESCRIPTION
windows-2019 image has been retired, so we need to migrate to windows-2022 or later.