### PR TITLE
fix: workaround for compilation errors on macOS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -111,7 +111,7 @@ http_archive(
         "-p1",
     ],
     patches = [
-        "@mediapipe//third_party:zlib.diff",
+        "@//third_party:zlib.patch",
     ],
     sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
     strip_prefix = "zlib-1.2.13",

--- a/third_party/zlib.patch
+++ b/third_party/zlib.patch
@@ -1,0 +1,86 @@
+diff --git a/contrib/minizip/ioapi.h b/contrib/minizip/ioapi.h
+index ae9ca7e..a5e0d07 100644
+--- a/contrib/minizip/ioapi.h
++++ b/contrib/minizip/ioapi.h
+@@ -21,7 +21,7 @@
+ #ifndef _ZLIBIOAPI64_H
+ #define _ZLIBIOAPI64_H
+ 
+-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
++#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__)) && (!defined(__ANDROID__))
+ 
+   // Linux needs this to support file operation on files larger then 4+GB
+   // But might need better if/def to select just the platforms that needs them.
+diff --git a/contrib/minizip/miniunz.c b/contrib/minizip/miniunz.c
+index 0dc9b50..f233a74 100644
+--- a/contrib/minizip/miniunz.c
++++ b/contrib/minizip/miniunz.c
+@@ -12,7 +12,7 @@
+          Copyright (C) 2009-2010 Mathias Svensson ( http://result42.com )
+ */
+ 
+-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
++#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__)) && (!defined(__ANDROID__))
+         #ifndef __USE_FILE_OFFSET64
+                 #define __USE_FILE_OFFSET64
+         #endif
+@@ -27,7 +27,7 @@
+         #endif
+ #endif
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(IOAPI_NO_64)
+ // In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions
+ #define FOPEN_FUNC(filename, mode) fopen(filename, mode)
+ #define FTELLO_FUNC(stream) ftello(stream)
+@@ -51,6 +51,7 @@
+ # include <direct.h>
+ # include <io.h>
+ #else
++# include <sys/stat.h>
+ # include <unistd.h>
+ # include <utime.h>
+ #endif
+diff --git a/contrib/minizip/minizip.c b/contrib/minizip/minizip.c
+index e8561b1..cb6327f 100644
+--- a/contrib/minizip/minizip.c
++++ b/contrib/minizip/minizip.c
+@@ -13,7 +13,7 @@
+ */
+ 
+ 
+-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
++#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__)) && (!defined(__ANDROID__))
+         #ifndef __USE_FILE_OFFSET64
+                 #define __USE_FILE_OFFSET64
+         #endif
+@@ -28,7 +28,7 @@
+         #endif
+ #endif
+ 
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(IOAPI_NO_64)
+ // In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions
+ #define FOPEN_FUNC(filename, mode) fopen(filename, mode)
+ #define FTELLO_FUNC(stream) ftello(stream)
+diff --git a/zutil.h b/zutil.h
+index 0bc7f4e..3a1b6a6 100644
+--- a/zutil.h
++++ b/zutil.h
+@@ -142,10 +142,12 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+ #      include <unix.h> /* for fdopen */
+-#    else
+-#      ifndef fdopen
+-#        define fdopen(fd,mode) NULL /* No fdopen() */
+-#      endif
++// 
++// FIXME: This is just a workaround to avoid compilation errors. Maybe we should check the compiler version.
++// #    else
++// #      ifndef fdopen
++// #        define fdopen(fd,mode) NULL /* No fdopen() */
++// #      endif
+ #    endif
+ #  endif
+ #endif


### PR DESCRIPTION
This fix is not correct (may break build for those who are using an older Xcode), but at least we can avoid errors on our CI environment. 

cf. https://github.com/google-ai-edge/mediapipe/issues/5943