### PR TITLE
Ensure that the path fed to MediaPipe contains only ASCII characters

### DIFF
--- a/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Util/ResourceUtil.cs
+++ b/Packages/com.github.homuler.mediapipe/Runtime/Scripts/Util/ResourceUtil.cs
@@ -90,7 +90,15 @@ namespace Mediapipe
         Logger.LogDebug(_TAG, $"{assetPath} is requested");
         if (TryGetFilePath(assetPath, out var filePath))
         {
-          return filePath;
+          if (PathHasNonAsciiChars(filePath))
+          {
+            string tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetFileName(filePath));
+            File.Copy(filePath, tempFilePath, true);
+            Logger.LogDebug(_TAG, $"Path {filePath} contains non-ASCII characters. Copied to temp file path: {tempFilePath}");
+            return tempFilePath;
+          }
+          else
+            return filePath;
         }
         throw new KeyNotFoundException($"Failed to find the file path for `{assetPath}`");
       }
@@ -150,6 +158,19 @@ namespace Mediapipe
             return $"{assetName}{extension}";
           }
       }
+    }
+
+    private static bool PathHasNonAsciiChars(string path)
+    {
+      foreach (var c in path)
+      {
+        if (c > 127)
+        {
+          return true;
+        }
+      }
+
+      return false;
     }
   }
 }


### PR DESCRIPTION
Fix for https://github.com/homuler/MediaPipeUnityPlugin/issues/1284

MediaPipe seems to fail to load assets from folders containing Japanese characters on Windows. After debugging the C++ side, couldn't find any obvious problem without going into MediaPipe itself.

As a workaround, I added a step to check if the asset path contains non-ASCII characters, and if this is the case, make a copy to a temporary path.